### PR TITLE
Rename `URI` abbreviations

### DIFF
--- a/aas_core_meta/v3rc1.py
+++ b/aas_core_meta/v3rc1.py
@@ -2019,7 +2019,7 @@ assert set(literal.value for literal in Key_type) == set(
 
 @reference_in_the_book(section=(4, 7, 13, 2))
 class Data_type_def(Enum):
-    Any_uri = "anyUri"
+    Any_URI = "anyUri"
     Base64_binary = "base64Binary"
     Boolean = "boolean"
     Date = "date"


### PR DESCRIPTION
We replace `*_uri` to `*_URI` to make for better identifiers in target
languages.