### PR TITLE
Rename `json_serialization` to `serialization`

### DIFF
--- a/aas_core_meta/marker.py
+++ b/aas_core_meta/marker.py
@@ -72,15 +72,17 @@ class reference_in_the_book:
         return func
 
 
-class json_serialization:
-    """Mark the settings for JSON serialization."""
+class serialization:
+    """Mark the settings for the general serialization schemas."""
 
     def __init__(self, with_model_type: bool) -> None:
         """
         Initialize with the given values.
 
         :param with_model_type:
-            The class needs to include ``modelType`` property in the serialization
+            The serialization needs to specify the concrete type since the given
+            type is abstract and the implemented de-serializations need to know the
+            concrete type up-front.
         """
         self.with_model_type = with_model_type
 

--- a/aas_core_meta/v3rc1.py
+++ b/aas_core_meta/v3rc1.py
@@ -9,7 +9,7 @@ from aas_core_meta.marker import (
     abstract,
     template,
     implementation_specific,
-    json_serialization,
+    serialization,
     reference_in_the_book,
     Ref,
     associate_ref_with,
@@ -109,7 +109,7 @@ class Has_extensions(DBC):
 
 @abstract
 @invariant(lambda self: is_ID_short(self.ID_short), "Constraint AASd-002")
-@json_serialization(with_model_type=True)
+@serialization(with_model_type=True)
 @reference_in_the_book(section=(4, 7, 2, 2))
 class Referable(Has_extensions):
     """
@@ -441,7 +441,7 @@ class Constraint(DBC):
 #     "Constraint AASd-020"
 # )
 @reference_in_the_book(section=(4, 7, 2, 11))
-@json_serialization(with_model_type=True)
+@serialization(with_model_type=True)
 # fmt: on
 class Qualifier(Constraint, Has_semantics):
     """
@@ -487,7 +487,7 @@ class Qualifier(Constraint, Has_semantics):
 
 
 @reference_in_the_book(section=(4, 7, 2, 12))
-@json_serialization(with_model_type=True)
+@serialization(with_model_type=True)
 class Formula(Constraint):
     """
     A formula is used to describe constraints by a logical expression.


### PR DESCRIPTION
The serialization needs to specify the concrete type since the given
type is abstract and the implemented de-serializations need to know
the concrete type up-front.

Therefore, the previous JSON serialization settings generalize also to
all serializations (including XML).