### PR TITLE
Make `Constraint` model-typed in V3RC1

### DIFF
--- a/aas_core_meta/v3rc1.py
+++ b/aas_core_meta/v3rc1.py
@@ -429,6 +429,7 @@ class Qualifiable(DBC):
 
 @abstract
 @reference_in_the_book(section=(4, 7, 2, 9))
+@serialization(with_model_type=True)
 class Constraint(DBC):
     """A constraint is used to further qualify or restrict an element."""
 


### PR DESCRIPTION
The `Constraint` shows up in properties, but it is an abstract class.
Therefore, the deserializers need to know the model type upfront.