### PR TITLE
Add Fragment in V3.0RC01

### DIFF
--- a/aas_core_meta/marker.py
+++ b/aas_core_meta/marker.py
@@ -55,18 +55,25 @@ class reference_in_the_book:
 
     @require(lambda section: all(number >= 1 for number in section))
     @require(lambda index: index >= 0)
-    def __init__(self, section: Tuple[int, ...], index: int = 0) -> None:
+    def __init__(self, section: Tuple[int, ...], index: int = 0, fragment: str = "") ->\
+            None:
         """
         Initialize with the given values.
 
         :param section: Section of the book given as tuple (so that it is sortable)
         :param index:
             Index in the section.
-
             The index helps us distinguish between multiple definitions in a section.
+        :param fragment:
+            Title of (Sub-)Section for anchor.
         """
         self.section = section
         self.index = index
+        if fragment == "":
+            fragment = '.'.join(section)+' '+classname +' Attributes'
+            fragment = fragment.replace(' ', '%20')
+
+        self.fragment = fragment
 
     def __call__(self, func: Type[T]) -> Type[T]:
         return func

--- a/aas_core_meta/v3rc1.py
+++ b/aas_core_meta/v3rc1.py
@@ -17,7 +17,7 @@ from aas_core_meta.marker import (
 from aas_core_meta.verification import is_IRI, is_IRDI, is_ID_short
 
 __book_url__ = "https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/Details_of_the_Asset_Administration_Shell_Part1_V3.pdf?__blob=publicationFile&v=5"
-__book_version__ = "V3.0RC1"
+__book_version__ = "V3.0RC01"
 
 
 # TODO (mristin, 2021-10-27): check the order of properties in the constructor
@@ -25,7 +25,8 @@ __book_version__ = "V3.0RC1"
 
 
 @abstract
-@reference_in_the_book(section=(4, 7, 2, 7))
+@reference_in_the_book(section=(4, 7, 2, 7), fragment="4.7.2.1%20Extensions%20("
+                                                      "HasExtensions)")
 class Has_semantics(DBC):
     """
     Element that can have a semantic definition.
@@ -89,7 +90,9 @@ class Extension(Has_semantics):
 
 
 @abstract
-@reference_in_the_book(section=(4, 7, 2, 1))
+@reference_in_the_book(section=(4, 7, 2, 1),
+                       fragment="4.7.2.7%20Semantic%20References%20Attributes%20("
+                                "HasSemantics))")
 class Has_extensions(DBC):
     """
     Element that can be extended by proprietary extensions.
@@ -318,7 +321,9 @@ class Modeling_kind(Enum):
 
 
 @abstract
-@reference_in_the_book(section=(4, 7, 2, 5), index=0)
+@reference_in_the_book(section=(4, 7, 2, 5), index=0,
+                       fragment="4.7.2.5%20Template%20or%20Instance%20of%20Model"
+                                "%20Element%20Attributes%20(HasKind)")
 class Has_kind(DBC):
     """
     An element with a kind is an element that can either represent a template or an
@@ -342,7 +347,10 @@ class Has_kind(DBC):
 
 
 @abstract
-@reference_in_the_book(section=(4, 7, 2, 13))
+@reference_in_the_book(section=(4, 7, 2, 13),
+                       fragment="4.7.2.13%20Used%20Templates%20for%20Data"
+                                "%20Specification%20Attributes%20("
+                                "HasDataSpecification)")
 class Has_data_specification(DBC):
     """
     Element that can be extended by using data specification templates.
@@ -1839,7 +1847,9 @@ class View(Referable, Has_semantics, Has_data_specification):
 
 
 @invariant(lambda self: len(self.keys) >= 1)
-@reference_in_the_book(section=(4, 7, 11))
+@reference_in_the_book(section=(4, 7, 11),
+                       fragment="4.7.11%20Referencing%20in%20Asset%20Administration"
+                                "%20Shells")
 class Reference(DBC):
     """
     Reference to either a model element of the same or another AAs or to an external
@@ -1881,7 +1891,9 @@ associate_ref_with(cls=Reference)
     or (self.ID_type != Key_type.ID_short and self.ID_type != Key_type.Fragment_ID),
     "Constraint AASd-081"
 )
-@reference_in_the_book(section=(4, 7, 11), index=1)
+@reference_in_the_book(section=(4, 7, 11), index=1,
+                       fragment="4.7.11%20Referencing%20in%20Asset%20Administration"
+                                "%20Shells")
 # fmt: on
 class Key(DBC):
     """A key is a reference to an element by its id."""
@@ -1921,7 +1933,9 @@ class Key(DBC):
         self.ID_type = ID_type
 
 
-@reference_in_the_book(section=(4, 7, 11), index=4)
+@reference_in_the_book(section=(4, 7, 11), index=4,
+                       fragment="4.7.11%20Referencing%20in%20Asset%20Administration"
+                                "%20Shells")
 class Identifiable_elements(Enum):
     """Enumeration of all identifiable elements within an asset administration shell."""
 
@@ -1931,7 +1945,9 @@ class Identifiable_elements(Enum):
     Submodel = "Submodel"
 
 
-@reference_in_the_book(section=(4, 7, 11), index=3)
+@reference_in_the_book(section=(4, 7, 11), index=3,
+                       fragment="4.7.11%20Referencing%20in%20Asset%20Administration"
+                                "%20Shells")
 @is_superset_of(enums=[Identifiable_elements])
 class Referable_elements(Enum):
     """Enumeration of all referable elements within an asset administration shell"""
@@ -1988,7 +2004,9 @@ class Referable_elements(Enum):
     View = "View"
 
 
-@reference_in_the_book(section=(4, 7, 11), index=2)
+@reference_in_the_book(section=(4, 7, 11), index=2,
+                       fragment="4.7.11%20Referencing%20in%20Asset%20Administration"
+                                "%20Shells")
 @is_superset_of(enums=[Referable_elements])
 class Key_elements(Enum):
     """Enumeration of different key value types within a key."""
@@ -2059,7 +2077,9 @@ class Key_elements(Enum):
     View = "View"
 
 
-@reference_in_the_book(section=(4, 7, 11), index=6)
+@reference_in_the_book(section=(4, 7, 11), index=6,
+                       fragment="4.7.11%20Referencing%20in%20Asset%20Administration"
+                                "%20Shells")
 class Local_key_type(Enum):
     """Enumeration of different key value types within a key."""
 
@@ -2070,7 +2090,9 @@ class Local_key_type(Enum):
     """Identifier of a fragment within a file"""
 
 
-@reference_in_the_book(section=(4, 7, 11), index=5)
+@reference_in_the_book(section=(4, 7, 11), index=5,
+                       fragment="4.7.11%20Referencing%20in%20Asset%20Administration"
+                                "%20Shells")
 @is_superset_of(enums=[Local_key_type, Identifier_type])
 class Key_type(Enum):
     """Enumeration of different key value types within a key."""
@@ -2094,7 +2116,7 @@ class Key_type(Enum):
     """Custom identifiers like GUIDs (globally unique identifiers)"""
 
 
-@reference_in_the_book(section=(4, 7, 13, 2))
+@reference_in_the_book(section=(4, 7, 13, 2), fragment="4.7.13.2%20Data%20Types")
 class Data_type_def(Enum):
     Any_URI = "anyUri"
     Base64_binary = "base64Binary"
@@ -2143,7 +2165,8 @@ class Data_type_def(Enum):
 
 
 @implementation_specific
-@reference_in_the_book(section=(4, 7, 13, 2), index=2)
+@reference_in_the_book(section=(4, 7, 13, 2), index=2,
+                       fragment="4.7.13.2%20Data%20Types")
 class Lang_string_set(DBC):
     """
     A set of strings, each annotated by the language of the string.
@@ -2153,14 +2176,18 @@ class Lang_string_set(DBC):
 
 
 @abstract
-@reference_in_the_book(section=(4, 8, 1))
+@reference_in_the_book(section=(4, 8, 1),
+                       fragment="4.8.1%20Concept%20of%20Data%20Specification"
+                                "%20Templates")
 class Data_specification_content(DBC):
     # No table for class in the book
     # to be implemented
     pass
 
 
-@reference_in_the_book(section=(4, 8, 2), index=3)
+@reference_in_the_book(section=(4, 8, 2), index=3,
+                       fragment="4.8.2%20Predefined%20Templates%20for%20Property"
+                                "%20and%20Value%20Descriptions")
 class Data_type_IEC_61360(Enum):
     Date = "DATE"
     String = "STRING"
@@ -2179,7 +2206,9 @@ class Data_type_IEC_61360(Enum):
     Timestamp = "TIMESTAMP"
 
 
-@reference_in_the_book(section=(4, 8, 2), index=4)
+@reference_in_the_book(section=(4, 8, 2), index=4,
+                       fragment="4.8.2%20Predefined%20Templates%20for%20Property"
+                                "%20and%20Value%20Descriptions")
 class Level_type(Enum):
     Min = "Min"
     Max = "Max"
@@ -2187,7 +2216,9 @@ class Level_type(Enum):
     Type = "Type"
 
 
-@reference_in_the_book(section=(4, 7, 8, 2), index=2)
+@reference_in_the_book(section=(4, 8, 2), index=2,
+                       fragment="4.8.2%20Predefined%20Templates%20for%20Property"
+                                "%20and%20Value%20Descriptions")
 class Value_reference_pair(DBC):
     """
     A value reference pair within a value list. Each value has a global unique id
@@ -2209,7 +2240,9 @@ class Value_reference_pair(DBC):
         self.value_ID = value_ID
 
 
-@reference_in_the_book(section=(4, 7, 8, 2), index=1)
+@reference_in_the_book(section=(4, 8, 2), index=1,
+                       fragment="4.8.2%20Predefined%20Templates%20for%20Property"
+                                "%20and%20Value%20Descriptions")
 class Value_list(DBC):
     """
     A set of value reference pairs.
@@ -2226,7 +2259,9 @@ class Value_list(DBC):
         self.value_reference_pair_types = value_reference_pair_types
 
 
-@reference_in_the_book(section=(4, 7, 8, 2))
+@reference_in_the_book(section=(4, 8, 2),
+                       fragment="4.8.2%20Predefined%20Templates%20for%20Property"
+                                "%20and%20Value%20Descriptions")
 class Data_specification_IEC_61360(Data_specification_content):
     """
     Content of data specification template for concept descriptions conformant to
@@ -2370,7 +2405,9 @@ class Data_specification_IEC_61360(Data_specification_content):
         self.level_type = level_type
 
 
-@reference_in_the_book(section=(4, 8, 3))
+@reference_in_the_book(section=(4, 8, 3),
+                       fragment="4.8.3%20Predefined%20Templates%20for%20Unit"
+                                "%20Concept%20Descriptions")
 class Data_specification_physical_unit(Data_specification_content):
     # TODO (sadu, 2021-11-17): No table for class in the book
 


### PR DESCRIPTION
Introduce attribute fragment for the marker @reference_in_the_book

The Fragment allows us to link back to the (sub-)section in the source of the spec PDF.