### PR TITLE
Make postfixes after SHACL review of V3RC01

### DIFF
--- a/aas_core_meta/v3rc1.py
+++ b/aas_core_meta/v3rc1.py
@@ -2419,6 +2419,7 @@ class Value_reference_pair(DBC):
         self.value_ID = value_ID
 
 
+@invariant(lambda self: len(self.value_reference_pair_types) >= 1)
 @reference_in_the_book(
     section=(4, 8, 2),
     index=1,


### PR DESCRIPTION
This patch comprises post-fixes which were omitted by mistake after the
review against the "official" SHACL schema for V3RC01.