### PR TITLE
Add aas-core-codegen to pre-commit checks

### DIFF
--- a/.idea/dictionaries/rist.xml
+++ b/.idea/dictionaries/rist.xml
@@ -2,6 +2,7 @@
   <dictionary name="rist">
     <words>
       <w>braunisch</w>
+      <w>codegen</w>
       <w>eclass</w>
       <w>icid</w>
       <w>icontract</w>

--- a/precommit.py
+++ b/precommit.py
@@ -4,6 +4,7 @@ import argparse
 import enum
 import os
 import pathlib
+import shlex
 import subprocess
 import sys
 
@@ -12,6 +13,7 @@ class Step(enum.Enum):
     BLACK = "black"
     MYPY = "mypy"
     RUN = "run"
+    AAS_CORE_CODEGEN_SMOKE = "aas-core-codegen-smoke"
     CHECK_INIT_AND_SETUP_COINCIDE = "check-init-and-setup-coincide"
 
 
@@ -101,6 +103,8 @@ def main() -> int:
     else:
         print("Skipped mypy'ing.")
 
+    module_dir = repo_root / "aas_core_meta"
+
     if Step.RUN in selects and Step.RUN not in skips:
         print(
             "Running the meta-models "
@@ -110,20 +114,33 @@ def main() -> int:
         env = os.environ.copy()
         env["ICONTRACT_SLOW"] = "true"
 
-        module_dir = repo_root / "aas_core_meta"
-        for pth in module_dir.iterdir():
-            if pth.is_file() and pth.name.startswith("v") and pth.name.endswith(".py"):
-                exit_code = subprocess.call(
-                    [sys.executable, str(pth)], cwd=str(repo_root)
-                )
+        for pth in sorted(pth for pth in module_dir.glob("v*.py") if pth.is_file()):
+            exit_code = subprocess.call([sys.executable, str(pth)], cwd=str(repo_root))
 
-                if exit_code != 0:
-                    print(
-                        f"Failed to execute with python interpreter "
-                        f"{sys.executable}: {pth}",
-                        file=sys.stderr,
-                    )
-                    return 1
+            if exit_code != 0:
+                print(
+                    f"Failed to execute with python interpreter "
+                    f"{sys.executable}: {pth}",
+                    file=sys.stderr,
+                )
+                return 1
+
+    if (
+        Step.AAS_CORE_CODEGEN_SMOKE in selects
+        and Step.AAS_CORE_CODEGEN_SMOKE not in skips
+    ):
+        print("Running smoke tests with aas-core-codegen-smoke...")
+
+        for pth in sorted(pth for pth in module_dir.glob("v*.py") if pth.is_file()):
+            cmd = ["aas-core-codegen-smoke", "--model_path", str(pth)]
+
+            exit_code = subprocess.call(cmd, cwd=str(repo_root))
+            if exit_code != 0:
+                cmd_text = " ".join(shlex.quote(part) for part in cmd)
+                print(f"Failed to execute: {cmd_text!r}", file=sys.stderr)
+                return 1
+    else:
+        print("Skipped smoke tests with aas-core-codegen-smoke.")
 
     if (
         Step.CHECK_INIT_AND_SETUP_COINCIDE in selects

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         "dev": [
             "black==21.11b0",
             "mypy==0.910",
+            "aas-core-codegen==0.0.6"
         ],
     },
     # fmt: on


### PR DESCRIPTION
We add the latest version of aas-core-codegen to the pre-commit checks
so that we discover meta-model inconcisistencies as early as possible.