### PR TITLE
Fix dangling reference in data specs for V3RC02

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -3025,7 +3025,8 @@ class Data_specification_IEC61360(Data_specification_content):
     Value
 
     :constraint AASd-101:
-        If :attr:`~category` equal to ``VALUE`` then :attr:`~value` shall be set.
+        If :attr:`~Referable.category` equal to ``VALUE`` then :attr:`~value` shall be
+        set.
 
     :constraint AASd-102:
         If :attr:`~value` or :attr:`~value_id` is not empty then :attr:`~value_list`


### PR DESCRIPTION
There was a dangling reference in the data specification. We referred to
the attribute `category`, but the data specification is referred to and
has no attribute `category`.

This dangling reference has not been discovered due to the bug in
aas-core-codegen.