### PR TITLE
Release 2022.4.30a1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,11 @@
+..
+    NOTE (mristin, 2021-12-27):
+    Please keep this file at 72 line width so that we can copy-paste
+    the release logs directly into commit messages.
+
+2022.4.30a1 (2022-04-07)
+========================
+This is a pre-release of the major release coming up on 2022-04-30.
+
+* Revisit V3RC01 and V3RC02 according to the current state of the book.
+* Formalize the constraints as invariants for V3RC02.

--- a/aas_core_meta/__init__.py
+++ b/aas_core_meta/__init__.py
@@ -1,8 +1,6 @@
 """Provide meta-models for Asset Administration Shell information model."""
 
-__version__ = "2021.11.20a2"
-__author__ = (
-    "Nico Braunisch, Marko Ristin, Robert Lehmann, Marcin Sadurski, Manuel Sauer"
-)
+__version__ = "2022.4.30a1"
+__author__ = "Nico Braunisch, Marko Ristin, Marcin Sadurski"
 __license__ = "License :: OSI Approved :: MIT License"
 __status__ = "Alpha"

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,11 @@ with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as fid:
 
 setup(
     name="aas-core-meta",
-    version="2021.11.20a2",
+    version="2022.4.30a1",
     description="Provide meta-models for Asset Administration Shell information model.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core-meta",
-    author="Nico Braunisch, Marko Ristin, Robert Lehmann, Marcin Sadurski, Manuel Sauer",
+    author="Nico Braunisch, Marko Ristin, Marcin Sadurski",
     author_email="rist@zhaw.ch",
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
This is a pre-release of the major release coming up on 2022-04-30.

* Revisit V3RC01 and V3RC02 according to the current state of the book.
* Formalize the constraints as invariants for V3RC02.