### PR TITLE
Fix docstring for ``matches_BCP_47`` in V3RC02

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -192,7 +192,8 @@ def matches_RFC_8089_path(text: str) -> bool:
 # noinspection SpellCheckingInspection
 @verification
 def matches_BCP_47(text: str) -> bool:
-    """Check that :paramref:`text` is a valid BCP 47 language tag.
+    """
+    Check that :paramref:`text` is a valid BCP 47 language tag.
 
     See: https://en.wikipedia.org/wiki/IETF_language_tag
     """


### PR DESCRIPTION
When a triple quote is left on the same line as the docstring, it
produces a block quote which we actually do not parse in
aas-core-codegen.