### PR TITLE
Release 2022.4.30a2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,14 @@
 
 2022.4.30a1 (2022-04-07)
 ========================
-This is a pre-release of the major release coming up on 2022-04-30.
+This is a pre-release version.
+
+* Remove redundant nullability checks in V3RC02 (#55)
+* Fix docstring for ``matches_BCP_47`` in V3RC02 (#54)
+
+2022.4.30a1 (2022-04-07)
+========================
+This is a pre-release version.
 
 * Revisit V3RC01 and V3RC02 according to the current state of the book.
 * Formalize the constraints as invariants for V3RC02.

--- a/aas_core_meta/__init__.py
+++ b/aas_core_meta/__init__.py
@@ -1,6 +1,6 @@
 """Provide meta-models for Asset Administration Shell information model."""
 
-__version__ = "2022.4.30a1"
+__version__ = "2022.4.30a2"
 __author__ = "Nico Braunisch, Marko Ristin, Marcin Sadurski"
 __license__ = "License :: OSI Approved :: MIT License"
 __status__ = "Alpha"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as fid:
 
 setup(
     name="aas-core-meta",
-    version="2022.4.30a1",
+    version="2022.4.30a2",
     description="Provide meta-models for Asset Administration Shell information model.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core-meta",


### PR DESCRIPTION
This is a pre-release version.

* Remove redundant nullability checks in V3RC02 (#55)
* Fix docstring for ``matches_BCP_47`` in V3RC02 (#54)