### PR TITLE
Update ``aas-core-codegen`` to 0.0.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "dev": [
             "black==22.3.0",
             "mypy==0.910",
-            "aas-core-codegen==0.0.6"
+            "aas-core-codegen==0.0.7"
         ],
     },
     # fmt: on


### PR DESCRIPTION
We use ``aas-core-codegen`` to run smoke tests in order to ensure that
the meta-models can be translated into programming code and schemas.
This helps us discover the errors as early as possible.