### PR TITLE
Check category only if set in V3RC02

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -2262,9 +2262,12 @@ class Submodel_element_struct(Submodel_element):
 
 @abstract
 @invariant(
-    lambda self: self.category == "CONSTANT"
-    or self.category == "PARAMETER"
-    or self.category == "VARIABLE",
+    lambda self: not (self.category is not None)
+    or (
+        self.category == "CONSTANT"
+        or self.category == "PARAMETER"
+        or self.category == "VARIABLE"
+    ),
     "Constraint AASd-090: For data elements category shall be one "
     "of the following values: CONSTANT, PARAMETER or VARIABLE",
 )


### PR DESCRIPTION
We fix the invariant that checked the value of a category such that it
only applies if the category has been set, as the category is an
optional property.