### PR TITLE
Fix the non-sensical invariant in Entity in V3RC02

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -2828,10 +2828,10 @@ class Entity_type(Enum):
         and (
             (
                 self.global_asset_id is not None
-                and self.global_asset_id is None
+                and self.specific_asset_id is None
             ) or (
                 self.global_asset_id is None
-                and self.global_asset_id is not None
+                and self.specific_asset_id is not None
             )
         )
     ) or (


### PR DESCRIPTION
We had a mistake in the invariant of the ``Entity`` class that was
always failing. Namely, we have to XOR global asset ID and specific
asset ID, but we simply XOR'ed the values with themselves.