### PR TITLE
Remove setting default values in constructors

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -1513,7 +1513,7 @@ class Has_kind(DBC):
     """
 
     def __init__(self, kind: Optional["Modeling_kind"] = None) -> None:
-        self.kind = kind if kind is not None else Modeling_kind.Instance
+        self.kind = kind
 
 
 @abstract


### PR DESCRIPTION
We remove the assignment of default values to properties in constructors
in V3RC02 since the book is not explicit about how this should be
implemented. If we set the properties to default values, the client can
not distinguish anymore between the case "no value provided" and "the
explicit value has been provided".

While it might be easier for the client to simply see what value is
there (and many clients might want to disregard the case whether it was
simply the default set in constructor or the actual explicit assignment
of a value), this behavior also makes for surprising round-trip logic
where the de-serialization -- serialization does not give the result
equal to the expected starting point.