### PR TITLE
Release 2022.5.30a1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,17 @@
     Please keep this file at 72 line width so that we can copy-paste
     the release logs directly into commit messages.
 
+2022.5.30a1 (2022-05-18)
+========================
+This is a pre-release version.
+
+* Introduce ``get_*_or_default`` as methods to V3rc2 (#71)
+* Remove setting default values in constructors (#70)
+* Fix the nonsensical invariant in Entity in V3RC02 (#69)
+* Check category only if set in V3RC02 (#68)
+* Fix invariants in V3RC02 (#67)
+
+
 2022.4.30a6 (2022-04-20)
 ========================
 This is a pre-release version.

--- a/aas_core_meta/__init__.py
+++ b/aas_core_meta/__init__.py
@@ -1,6 +1,6 @@
 """Provide meta-models for Asset Administration Shell information model."""
 
-__version__ = "2022.4.30a6"
+__version__ = "2022.5.30a1"
 __author__ = "Nico Braunisch, Marko Ristin, Marcin Sadurski"
 __license__ = "License :: OSI Approved :: MIT License"
 __status__ = "Alpha"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as fid:
 
 setup(
     name="aas-core-meta",
-    version="2022.4.30a6",
+    version="2022.5.30a1",
     description="Provide meta-models for Asset Administration Shell information model.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core-meta",


### PR DESCRIPTION
This is a pre-release version.

* Introduce ``get_*_or_default`` as methods to V3rc2 (#71)
* Remove setting default values in constructors (#70)
* Fix the nonsensical invariant in Entity in V3RC02 (#69)
* Check category only if set in V3RC02 (#68)
* Fix invariants in V3RC02 (#67)