### PR TITLE
Reference default values in V3RC02

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -1253,7 +1253,7 @@ class Extension(Has_semantics):
     """
     Type of the value of the extension.
 
-    Default: xsd:string
+    Default: :attr:`~Data_type_def_XSD.String`
     """
 
     @implementation_specific
@@ -1517,7 +1517,7 @@ class Has_kind(DBC):
     """
     Kind of the element: either type or instance.
 
-    Default Value = Instance
+    Default: :attr:`~Modeling_kind.Instance`
     """
 
     @implementation_specific


### PR DESCRIPTION
We use attribute references (``:attr:``) to reference default values for
the properties. This is useful as we would be reported an error if we
ever remove the referenced object from the meta-model, but forget to
update the documentation of a property.