### PR TITLE
Add verification for `xs:string` in v3RC02

### DIFF
--- a/.idea/dictionaries/rist.xml
+++ b/.idea/dictionaries/rist.xml
@@ -11,6 +11,8 @@
       <w>docx</w>
       <w>ebook</w>
       <w>eclass</w>
+      <w>fffe</w>
+      <w>ffff</w>
       <w>iana</w>
       <w>icid</w>
       <w>icontract</w>

--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -961,6 +961,22 @@ def matches_xs_negative_integer(text: str) -> bool:
     return match(pattern, text) is not None
 
 
+@verification
+def matches_xs_string(text: str) -> bool:
+    """
+    Check that :paramref:`text` conforms to the pattern of an ``xs:string``.
+
+    See: https://www.w3.org/TR/xmlschema11-2/#string
+
+    :param text: Text to be checked
+    :returns: True if the :paramref:`text` conforms to the pattern
+    """
+    # From: https://www.w3.org/TR/xml11/#NT-Char
+    # Any Unicode character, excluding the surrogate blocks, FFFE, and FFFF.
+    pattern = r"^[^\x00]*$"
+    return match(pattern, text) is not None
+
+
 # noinspection PyUnusedLocal
 @verification
 @implementation_specific

--- a/tests/test_v3rc2.py
+++ b/tests/test_v3rc2.py
@@ -855,6 +855,16 @@ class Test_matches_xs_negative_integer(unittest.TestCase):
         assert not v3rc2.matches_xs_negative_integer('+1')
 
 
+class Test_matches_xs_string(unittest.TestCase):
+    def test_empty(self) -> None:
+        assert v3rc2.matches_xs_string('')
+
+    def test_free_form_text(self) -> None:
+        assert v3rc2.matches_xs_string('some free & <free> \uffff \ufffe form text')
+
+    def test_nul(self) -> None:
+        assert not v3rc2.matches_xs_string('\x00')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
XML standard disallows `NUL` character and it can't be even encoded. We
therefore add a verification for such a character as a pattern.