### PR TITLE
Make pre-commit more user friendly

### DIFF
--- a/.idea/csv-plugin.xml
+++ b/.idea/csv-plugin.xml
@@ -45,6 +45,13 @@
             </Attribute>
           </value>
         </entry>
+        <entry key="\precommit.py">
+          <value>
+            <Attribute>
+              <option name="separator" value="," />
+            </Attribute>
+          </value>
+        </entry>
         <entry key="\tests\test_v3rc2.py">
           <value>
             <Attribute>

--- a/.idea/dictionaries/rist.xml
+++ b/.idea/dictionaries/rist.xml
@@ -29,6 +29,7 @@
       <w>nist</w>
       <w>nmtokens</w>
       <w>paramref</w>
+      <w>precommit</w>
       <w>referables</w>
       <w>ristin</w>
       <w>sadu</w>


### PR DESCRIPTION
We check for failures in commands called from pre-commit and report them
in a more user-friendly way. This is important for new contributors who
are not familiar with the precommit script and get scared away in case
of exceptions.