### PR TITLE
Add note about AASd-115 in V3RC02

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -22,6 +22,12 @@ Some of the constraints are not enforceable as they depend on the wider context
 such as language understanding, so we could not formalize them:
 
 * :constraintref:`AASd-012`
+
+We could not formalize the constraints which prescribed how to deal with
+the default values as these are not really constraints in the strict sense, but more
+a guideline on how to resolve default values:
+
+* :constraintref:`AASd-115`
 """
 
 from enum import Enum


### PR DESCRIPTION
We add a note explaining why the constraint AASd-115 is rather a
guideline than a constraint in the strict sense
(`semantic_id_list_element` should be assumed if the elements of
Submodel Element List have no semantic ID specified).