### PR TITLE
Make `RelationshipElement` concrete in V3RC02

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -2235,7 +2235,6 @@ class Submodel_element(
 
 
 @reference_in_the_book(section=(5, 7, 7, 14))
-@abstract
 class Relationship_element(Submodel_element):
     """
     A relationship element is used to define a relationship between two elements


### PR DESCRIPTION
We marked the class `RelationshipElement` abstract by mistake. It is
concrete in the book.

Fixes #97.