### PR TITLE
Release 2022.6.17

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,15 @@
     Please keep this file at 72 line width so that we can copy-paste
     the release logs directly into commit messages.
 
+2022.6.17
+=======
+This is a bug-fix version, where our spec turned out to be  incorrect
+from the programming point of view.
+
+* Fix invariant on specific_asset_id in V3RC2 (#108)
+* Fix length invariant of id-shorts in V3RC2 (#107)
+* Fix AnyURI patterns for UTF-32 (#106)
+
 2022.6.3 (2022-06-03)
 =====================
 In this version we fix a couple of inconsistencies with the book which

--- a/aas_core_meta/__init__.py
+++ b/aas_core_meta/__init__.py
@@ -1,6 +1,6 @@
 """Provide meta-models for Asset Administration Shell information model."""
 
-__version__ = "2022.6.3"
+__version__ = "2022.6.17"
 __author__ = "Nico Braunisch, Marko Ristin, Marcin Sadurski"
 __license__ = "License :: OSI Approved :: MIT License"
 __status__ = "Alpha"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as fid:
 
 setup(
     name="aas-core-meta",
-    version="2022.6.3",
+    version="2022.6.17",
     description="Provide meta-models for Asset Administration Shell information model.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core-meta",


### PR DESCRIPTION
This is a bug-fix version, where our spec turned out to be  incorrect
from the programming point of view.

* Fix invariant on specific_asset_id in V3RC2 (#108)
* Fix length invariant of id-shorts in V3RC2 (#107)
* Fix AnyURI patterns for UTF-32 (#106)