### PR TITLE
Remove unique idShort from list elements in V3RC02

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -2308,11 +2308,6 @@ class Relationship_element(Submodel_element):
 @invariant(
     lambda self:
     not (self.value is not None)
-    or id_shorts_are_unique(self.value)
-)
-@invariant(
-    lambda self:
-    not (self.value is not None)
     or all(
         element.id_short is None
         for element in self.value


### PR DESCRIPTION
The elements in a ``Submodel_element_list`` should have no ID-shorts,
hence also no unique ID-shorts.