### PR TITLE
Fix nullness in inv. AASd-119 in V3RC02

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -2095,11 +2095,14 @@ class Specific_asset_id(Has_semantics):
 @reference_in_the_book(section=(5, 7, 5))
 @invariant(
     lambda self:
-    not any(
-        qualifier.kind == Qualifier_kind.Template_qualifier
-        for qualifier in self.qualifiers
-    ) or (
-        self.kind_or_default() == Modeling_kind.Template
+    not (self.qualifiers is not None)
+    or (
+        not any(
+            qualifier.kind == Qualifier_kind.Template_qualifier
+            for qualifier in self.qualifiers
+        ) or (
+            self.kind_or_default() == Modeling_kind.Template
+        )
     ),
     "Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is "
     "equal to template qualifier and the qualified element has kind then the qualified "
@@ -2185,11 +2188,14 @@ class Submodel(
 @abstract
 @invariant(
     lambda self:
-    not any(
-        qualifier.kind == Qualifier_kind.Template_qualifier
-        for qualifier in self.qualifiers
-    ) or (
-        self.kind_or_default() == Modeling_kind.Template
+    not (self.qualifiers is not None)
+    or (
+        not any(
+            qualifier.kind == Qualifier_kind.Template_qualifier
+            for qualifier in self.qualifiers
+        ) or (
+            self.kind_or_default() == Modeling_kind.Template
+        )
     ),
     "Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is "
     "equal to template qualifier and the qualified element has kind then the qualified "

--- a/tests/test_v3rc2.py
+++ b/tests/test_v3rc2.py
@@ -1179,15 +1179,17 @@ Observed literals: {sorted(literal_set)!r}"""
     def test_constraint_119_in_all_qualifiable_with_has_kind(self) -> None:
         renegade_classes = []  # type: List[str]
 
-        expected_condition_str = (
-            "lambda self:\n"
-            "    not any(\n"
-            "        qualifier.kind == Qualifier_kind.Template_qualifier\n"
-            "        for qualifier in self.qualifiers\n"
-            "    ) or (\n"
-            "        self.kind_or_default() == Modeling_kind.Template\n"
-            "    )"
+        expected_condition_str = f"""\
+lambda self:
+    not (self.qualifiers is not None)
+    or (
+        not any(
+            qualifier.kind == Qualifier_kind.Template_qualifier
+            for qualifier in self.qualifiers
+        ) or (
+            self.kind_or_default() == Modeling_kind.Template
         )
+    )"""
 
         expected_description = (
             "Constraint AASd-119: If any qualifier kind value of "


### PR DESCRIPTION
We explicitly check for "is not None" in the invariants corresponding to
AASd-119 as the verification raises null assertions otherwise.