### PR TITLE
Fix `xs:string` pattern for V3RC02

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -1002,7 +1002,8 @@ def matches_xs_string(text: str) -> bool:
     """
     # From: https://www.w3.org/TR/xml11/#NT-Char
     # Any Unicode character, excluding the surrogate blocks, FFFE, and FFFF.
-    pattern = r"^[^\x00]*$"
+    # noinspection SpellCheckingInspection
+    pattern = r"^[\u0001-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$"
     return match(pattern, text) is not None
 
 

--- a/tests/test_v3rc2.py
+++ b/tests/test_v3rc2.py
@@ -879,7 +879,18 @@ class Test_matches_xs_string(unittest.TestCase):
         assert v3rc2.matches_xs_string("")
 
     def test_free_form_text(self) -> None:
-        assert v3rc2.matches_xs_string("some free & <free> \uffff \ufffe form text")
+        assert v3rc2.matches_xs_string("some free & <free> \u1984 form text")
+
+    def test_fffe(self) -> None:
+        assert not v3rc2.matches_xs_string("\uFFFE")
+
+    def test_ffff(self) -> None:
+        assert not v3rc2.matches_xs_string("\uFFFF")
+
+    # noinspection SpellCheckingInspection
+    def test_surrogate_characters(self) -> None:
+        assert not v3rc2.matches_xs_string("\uD800")
+        assert not v3rc2.matches_xs_string("\uDFFF")
 
     def test_nul(self) -> None:
         assert not v3rc2.matches_xs_string("\x00")


### PR DESCRIPTION
The previous pattern was too permissive and did not follow the
specification by the letter. We also learned a great deal about UTF-16
and UTF-32 along the way, so the previous pattern was also a reflection
of our own ignorance.