### PR TITLE
Release 2022.6.19

### DIFF
--- a/.idea/dictionaries/rist.xml
+++ b/.idea/dictionaries/rist.xml
@@ -32,6 +32,7 @@
       <w>mypy</w>
       <w>nist</w>
       <w>nmtokens</w>
+      <w>nullness</w>
       <w>paramref</w>
       <w>precommit</w>
       <w>referables</w>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,24 @@
     Please keep this file at 72 line width so that we can copy-paste
     the release logs directly into commit messages.
 
+2022.6.19
+=========
+This is a version with fixes which were necessary for generating
+the JSON test data automatically using aas-core3.0rc02-testgen,
+and making sure that the aas-core-codegen generates the C# code
+such that it passes all the unit tests for JSON.
+
+XML tests are still pending.
+
+* Invert AASd-119 in V3RC02 (#116)
+* Fix ``xs:string`` pattern for V3RC02 (#115)
+* Check non-none of message broker in inv. of V3RC02 (#114)
+* Fix nullness in inv. AASd-119 in V3RC02 (#113)
+* Remove ill-defined constraint 116 from V3RC02 (#111)
+* Remove unique idShort from list elements in V3RC02 (#110)
+
 2022.6.17
-=======
+=========
 This is a bug-fix version, where our spec turned out to be  incorrect
 from the programming point of view.
 

--- a/aas_core_meta/__init__.py
+++ b/aas_core_meta/__init__.py
@@ -1,6 +1,6 @@
 """Provide meta-models for Asset Administration Shell information model."""
 
-__version__ = "2022.6.17"
+__version__ = "2022.6.19"
 __author__ = "Nico Braunisch, Marko Ristin, Marcin Sadurski"
 __license__ = "License :: OSI Approved :: MIT License"
 __status__ = "Alpha"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as fid:
 
 setup(
     name="aas-core-meta",
-    version="2022.6.17",
+    version="2022.6.19",
     description="Provide meta-models for Asset Administration Shell information model.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core-meta",


### PR DESCRIPTION
This is a version with fixes which were necessary for generating
the JSON test data automatically using aas-core3.0rc02-testgen,
and making sure that the aas-core-codegen generates the C# code
such that it passes all the unit tests for JSON.

XML tests are still pending.

* Invert AASd-119 in V3RC02 (#116)
* Fix ``xs:string`` pattern for V3RC02 (#115)
* Check non-none of message broker in inv. of V3RC02 (#114)
* Fix nullness in inv. AASd-119 in V3RC02 (#113)
* Remove ill-defined constraint 116 from V3RC02 (#111)
* Remove unique idShort from list elements in V3RC02 (#110)