### PR TITLE
Enforce Extension value match type in V3RC02

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -1331,6 +1331,15 @@ class Has_semantics(DBC):
         self.supplemental_semantic_ids = supplemental_semantic_ids
 
 
+# fmt: off
+@invariant(
+    lambda self:
+    not (self.value is not None)
+    or (
+        value_consistent_with_xsd_type(self.value, self.value_type_or_default())
+    )
+)
+# fmt: on
 @reference_in_the_book(section=(5, 7, 2, 1), index=1)
 class Extension(Has_semantics):
     """


### PR DESCRIPTION
We forgot to add an invariant to ensure that the extension's value
matches its XSD type.