### PR TITLE
Release 2022.6.20

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,14 @@
     Please keep this file at 72 line width so that we can copy-paste
     the release logs directly into commit messages.
 
+2022.6.20
+=========
+This is a minor bug-fix version. We release it so we can start working
+on tests with XML data.
+
+* Enforce Extension value match type in V3RC02 (#119)
+* Revert back AASd-119 in V3RC02 (#118)
+
 2022.6.19
 =========
 This is a version with fixes which were necessary for generating

--- a/aas_core_meta/__init__.py
+++ b/aas_core_meta/__init__.py
@@ -1,6 +1,6 @@
 """Provide meta-models for Asset Administration Shell information model."""
 
-__version__ = "2022.6.19"
+__version__ = "2022.6.20"
 __author__ = "Nico Braunisch, Marko Ristin, Marcin Sadurski"
 __license__ = "License :: OSI Approved :: MIT License"
 __status__ = "Alpha"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as fid:
 
 setup(
     name="aas-core-meta",
-    version="2022.6.19",
+    version="2022.6.20",
     description="Provide meta-models for Asset Administration Shell information model.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core-meta",


### PR DESCRIPTION
This is a minor bug-fix version. We release it so we can start working
on tests with XML data.

* Enforce Extension value match type in V3RC02 (#119)
* Revert back AASd-119 in V3RC02 (#118)