### PR TITLE
Make data specification concrete

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -4356,7 +4356,6 @@ class Data_specification_content:
     """
 
 
-@abstract
 @reference_in_the_book(section=(6, 2, 1, 1))
 class Data_specification:
     """


### PR DESCRIPTION
We have to make ``DataSpecification`` concrete so that we can generate a
complete example of an environment.