### PR TITLE
Make ``DataSpecificationContent`` concrete

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -4346,7 +4346,6 @@ class Lang_string_set(DBC):
         self.lang_strings = lang_strings
 
 
-@abstract
 @reference_in_the_book(section=(6, 2, 1, 1), index=1)
 class Data_specification_content:
     """


### PR DESCRIPTION
We have to make ``DataSpecificationContent`` concrete so that we can
effectively test the ``Environment`` with a complete test example.