### PR TITLE
Formalize reference comparison in V3RC02

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -1185,6 +1185,25 @@ def data_element_category_is_valid(category: str) -> bool:
     )
 
 
+@verification
+@implementation_specific
+def reference_keys_and_type_equal(that: "Reference", other: "Reference") -> bool:
+    """Check that the two references are equal by comparing their keys and type."""
+    # NOTE (mristin, 2022-04-7):
+    # This implementation will not be transpiled, but is given here as reference.
+    if that.type != other.type:
+        return False
+
+    if len(that.keys) != len(other.keys):
+        return False
+
+    for that_key, other_key in zip(that.keys, other.keys):
+        if that_key.type != other_key.type or that_key.value != other_key.value:
+            return False
+
+    return True
+
+
 # endregion
 
 
@@ -2386,7 +2405,9 @@ class Relationship_element(Submodel_element):
     ) or (
         all(
             not (child.semantic_id is not None)
-            or child.semantic_id == self.semantic_id_list_element
+            or reference_keys_and_type_equal(
+                child.semantic_id,
+                self.semantic_id_list_element)
             for child in self.value
         )
     ),

--- a/additional-verbs-in-imperative-mood.txt
+++ b/additional-verbs-in-imperative-mood.txt
@@ -35,3 +35,4 @@ guard
 revise
 fork
 invert
+formalize


### PR DESCRIPTION
The constraint AASd-107 requires a reference comparison, but the
reference comparison has not been properly defined. Therefore we
introduce a separate function to formalize that references are compared
by their keys and type.