### PR TITLE
Re-format away trailing whitespace in CI

### DIFF
--- a/.idea/dictionaries/rist.xml
+++ b/.idea/dictionaries/rist.xml
@@ -35,6 +35,7 @@
       <w>nullness</w>
       <w>paramref</w>
       <w>precommit</w>
+      <w>pths</w>
       <w>referables</w>
       <w>ristin</w>
       <w>sadu</w>


### PR DESCRIPTION
We had problems with diffing files where whitespace slipped in.
Therefore we add a check / auto-healing fix in the pre-commit script to
explicitly check for the trailing whitespace, including also docstrings.

Black ignored docstrings so that was part of the problem.