### PR TITLE
Introduce constants

### DIFF
--- a/aas_core_meta/marker.py
+++ b/aas_core_meta/marker.py
@@ -11,6 +11,8 @@ from typing import (
     Any,
     Union,
     overload,
+    Set,
+    List,
 )
 
 from icontract import require
@@ -131,25 +133,89 @@ class serialization:
         return func
 
 
-EnumT = TypeVar("EnumT", bound=Enum)
-
-
-class is_superset_of:
-    """Mark the contained enumeration subsets of the decoratee."""
-
-    def __init__(self, enums: Sequence[Type[EnumT]]) -> None:
-        """
-        Initialize with the given values.
-
-        :param enums:
-            The contained subset enumerations
-        """
-        self.enums = enums
-
-    def __call__(self, func: Type[T]) -> Type[T]:
-        return func
-
-
 def verification(thing: CallableT) -> CallableT:
     """Mark the function as a verification function used in contracts."""
     return thing
+
+
+# noinspection PyUnusedLocal,PyShadowingNames
+def constant_bool(
+    value: bool,
+    description: Optional[str] = None,
+    reference_in_the_book: Optional[reference_in_the_book] = None,
+) -> bool:
+    """Define a constant boolean in the meta-model."""
+    return value
+
+
+# noinspection PyUnusedLocal,PyShadowingNames
+def constant_int(
+    value: int,
+    description: Optional[str] = None,
+    reference_in_the_book: Optional[reference_in_the_book] = None,
+) -> int:
+    """Define a constant integer in the meta-model."""
+    return value
+
+
+# noinspection PyUnusedLocal,PyShadowingNames
+def constant_float(
+    value: float,
+    description: Optional[str] = None,
+    reference_in_the_book: Optional[reference_in_the_book] = None,
+) -> float:
+    """Define a constant floating-point number in the meta-model."""
+    return value
+
+
+# noinspection PyUnusedLocal,PyShadowingNames
+def constant_str(
+    value: str,
+    description: Optional[str] = None,
+    reference_in_the_book: Optional[reference_in_the_book] = None,
+) -> str:
+    """Define a constant string in the meta-model."""
+    return value
+
+
+# noinspection PyUnusedLocal,PyShadowingNames
+def constant_bytearray(
+    value: bytearray,
+    description: Optional[str] = None,
+    reference_in_the_book: Optional[reference_in_the_book] = None,
+) -> bytearray:
+    """Define a constant bytearray in the meta-model."""
+    return value
+
+
+# noinspection PyUnusedLocal,PyShadowingNames
+def constant_set(
+    values: Sequence[T],
+    description: Optional[str] = None,
+    reference_in_the_book: Optional[reference_in_the_book] = None,
+    superset_of: Optional[Sequence[Set[T]]] = None,
+) -> Set[T]:
+    """
+    Define a constant set in the meta-model.
+
+    The values need to be given as a list so that we can follow the order in
+    the generated code.
+    """
+    result = set(values)
+
+    if superset_of is not None:
+        for i, subset in enumerate(superset_of):
+            offending_values = []  # type: List[T]
+            for value in subset:
+                if value not in result:
+                    offending_values.append(value)
+
+            if len(offending_values) > 0:
+                offending_values_str = ",\n".join(map(str, offending_values))
+                raise AssertionError(
+                    f"The following values "
+                    f"from the subset {i + 1} (index starts from 1) "
+                    f"are not contained in the values:\n{offending_values_str}"
+                )
+
+    return result

--- a/obsolete/2022-04-09/v3rc02-with-data-specifications/v3rc2.py
+++ b/obsolete/2022-04-09/v3rc02-with-data-specifications/v3rc2.py
@@ -1773,7 +1773,7 @@ class Asset_information(DBC):
     The asset may either represent an asset type or an asset instance.
     The asset has a globally unique identifier plus – if needed – additional domain
     specific (proprietary) identifiers. However, to support the corner case of very
-    first phase of lifecycle where a stabilised/constant global asset identifier does
+    first phase of lifecycle where a stabilised/constant_set global asset identifier does
     not already exist, the corresponding attribute
     :attr:`~global_asset_id` is optional.
 

--- a/obsolete/2022-06-30/v3rc1.py
+++ b/obsolete/2022-06-30/v3rc1.py
@@ -792,7 +792,7 @@ class Asset_information(DBC):
     The asset may either represent an asset type or an asset instance. The asset has
     a globally unique identifier plus – if needed – additional domain-specific
     (proprietary) identifiers. However, to support the corner case of very first
-    phase of lifecycle where a stabilized/constant global asset identifier does not
+    phase of lifecycle where a stabilized/constant_set global asset identifier does not
     already exist, the corresponding attribute :attr:`~global_asset_ID` is optional.
     """
 

--- a/tests/test_v3rc2.py
+++ b/tests/test_v3rc2.py
@@ -1118,7 +1118,7 @@ class Test_assertions(unittest.TestCase):
         if class_name_set != literal_set:
             errors.append(
                 f"""\
-The sub-classes of {v3rc2.Identifiable.__name__} do not correspond to {v3rc2.AAS_identifiables.__name__}.
+The sub-classes of {v3rc2.Identifiable.__name__} do not correspond to AAS_identifiables.
 
 Observed classes:  {sorted(class_name_set)!r}
 Observed literals: {sorted(literal_set)!r}"""
@@ -1150,7 +1150,33 @@ Observed literals: {sorted(literal_set)!r}"""
         if class_name_set != literal_set:
             errors.append(
                 f"""\
-The sub-classes of {v3rc2.Referable.__name__} which are not {v3rc2.Identifiable.__name__} do not correspond to {v3rc2.AAS_referable_non_identifiables.__name__}.
+The sub-classes of {v3rc2.Referable.__name__} which are not {v3rc2.Identifiable.__name__} do not correspond to AAS_referable_non_identifiables.
+
+Observed classes:  {sorted(class_name_set)!r}
+Observed literals: {sorted(literal_set)!r}"""
+            )
+
+        if len(errors) != 0:
+            raise AssertionError("\n".join(f"* {error}" for error in errors))
+
+    def test_AAS_submodel_elements_as_keys_corresponds_to_classes(self) -> None:
+        errors = []  # type: List[str]
+
+        class_name_set = set()  # type: Set[str]
+
+        for name, obj in inspect.getmembers(v3rc2, inspect.isclass):
+            if obj.__module__ != v3rc2.__name__:
+                continue
+
+            if issubclass(obj, v3rc2.Submodel_element):
+                class_name_set.add(name)
+
+        literal_set = {literal.name for literal in v3rc2.AAS_submodel_elements_as_keys}
+
+        if class_name_set != literal_set:
+            errors.append(
+                f"""\
+The sub-classes of {v3rc2.Submodel_element.__name__} do not correspond to AAS_submodel_elements_as_keys.
 
 Observed classes:  {sorted(class_name_set)!r}
 Observed literals: {sorted(literal_set)!r}"""


### PR DESCRIPTION
This is a major change. We introduce constants in the meta-model
including constant primitive values, constant sets of primitive values
as well as constant sets of enumeration literals.

The continuous integration is expected to fail as we change
aas-core-codegen in parallel, and this change is incompatible with the
current main branch of aas-core-codegen.