### PR TITLE
Update aas-core-codegen to 6b55dbc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "dev": [
             "black==22.3.0",
             "mypy==0.910",
-            "aas-core-codegen==0.0.10",
+            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@6b55dbc#egg=aas-core-codegen",
             "astpretty==3.0.0"
         ],
     },


### PR DESCRIPTION
We update the dependencies to [aas-core-codegen 6b55dbc] so that the
continuous integration, which failed as planned in the previous commit,
can now pass.

[aas-core-codegen 6b55dbc]: https://github.com/aas-core-works/aas-core-codegen/commit/6b55dbc