### PR TITLE
Update aas-core-codegen to f698a1c

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "dev": [
             "black==22.3.0",
             "mypy==0.910",
-            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@6b55dbc#egg=aas-core-codegen",
+            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@f698a1c#egg=aas-core-codegen",
             "astpretty==3.0.0"
         ],
     },


### PR DESCRIPTION
We update the aas-core-codegen as dependency to
[aas-core-codegen f698a1c]. In the previous commit, the remote CI failed
as we had to update both aas-core-meta and aas-core-codegen in sync.

With this change, the remote CI runs again.

[aas-core-codegen f698a1c]: https://github.com/aas-core-works/aas-core-codegen/commit/f698a1c