### PR TITLE
Update to aas-core-codegen a2ba2a5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "dev": [
             "black==22.3.0",
             "mypy==0.910",
-            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@f698a1c#egg=aas-core-codegen",
+            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@a2ba2a5#egg=aas-core-codegen",
             "astpretty==3.0.0"
         ],
     },


### PR DESCRIPTION
We update to [aas-core-codegen a2ba2a5] so that the remote CI runs
again which was intentionally broken in [ab276a8].

[ab276a8]: https://github.com/aas-core-works/aas-core-meta/commit/ab276a88135af94ba14fddc162a94ed1ac574758
[aas-core-codegen a2ba2a5]: https://github.com/aas-core-works/aas-core-codegen/commit/a2ba2a5