### PR TITLE
Define XML namespace

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -91,6 +91,7 @@ __book_url__ = (
 )
 __book_version__ = "V3.0RC02"
 
+__xml_namespace__ = "http://www.admin-shell.io/aas/3/0/RC02"
 
 # region Verification
 


### PR DESCRIPTION
We define the XML namespace for the whole meta-model. This is necessary
so that the generation of XSD, RDF+SHACL schemas and XML
de/serialization are all in sync.

The continuous integration is expected to fail, as it depends on
aas-core-codegen which also needs to change in sync.