### PR TITLE
Upgrade aas-core-codegen to dac0ca1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "dev": [
             "black==22.3.0",
             "mypy==0.910",
-            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@a2ba2a5#egg=aas-core-codegen",
+            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@dac0ca1#egg=aas-core-codegen",
             "astpretty==3.0.0"
         ],
     },


### PR DESCRIPTION
We upgrade the version of aas-core-codegen used in continuous
integration to dac0ca1 since it included breaking changes which we had
to update in sync with aas-core-meta.

The continuous integration is now expected to pass.