### PR TITLE
Enforce that lists have min. length 1 in V3RC02

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -1324,6 +1324,12 @@ class Id_short(str, DBC):
     "Constraint AASd-118: If there are supplemental semantic IDs defined "
     "then there shall be also a main semantic ID."
 )
+@invariant(
+    lambda self:
+    not (self.supplemental_semantic_ids is not None)
+    or len(self.supplemental_semantic_ids) > 0,
+    "Supplemental semantic IDs must be either null or have at least one item"
+)
 # fmt: on
 @reference_in_the_book(section=(5, 7, 2, 6))
 class Has_semantics(DBC):
@@ -1444,6 +1450,12 @@ class Extension(Has_semantics):
     not (self.extensions is not None) or extension_names_are_unique(self.extensions),
     "Constraint AASd-077: The name of an extension within Has-Extensions "
     "needs to be unique."
+)
+@invariant(
+    lambda self:
+    not (self.extensions is not None)
+    or len(self.extensions) > 0,
+    "Extensions must be either null or have at least one item"
 )
 # fmt: on
 class Has_extensions(DBC):
@@ -1668,8 +1680,16 @@ class Has_kind(DBC):
         self.kind = kind
 
 
+# fmt: off
 @abstract
+@invariant(
+    lambda self:
+    not (self.embedded_data_specifications is not None)
+    or len(self.embedded_data_specifications) > 0,
+    "Embedded data specifications must be either null or have at least one item"
+)
 @reference_in_the_book(section=(5, 7, 2, 9))
+# fmt: on
 class Has_data_specification(DBC):
     """
     Element that can be extended by using data specification templates.
@@ -1743,6 +1763,12 @@ class Administrative_information(Has_data_specification):
     or qualifier_types_are_unique(self.qualifiers),
     "Constraint AASd-021: Every qualifiable can only have one qualifier with "
     "the same type."
+)
+@invariant(
+    lambda self:
+    not (self.qualifiers is not None)
+    or len(self.qualifiers) > 0,
+    "Qualifiers must be either null or have at least one item"
 )
 @reference_in_the_book(section=(5, 7, 2, 7))
 @serialization(with_model_type=True)
@@ -1914,6 +1940,12 @@ class Qualifier(Has_semantics):
         )
     )
 )
+@invariant(
+    lambda self:
+    not (self.submodels is not None)
+    or len(self.submodels) > 0,
+    "Submodels must be either null or have at least one item"
+)
 # fmt: on
 class Asset_administration_shell(Identifiable, Has_data_specification):
     """An asset administration shell."""
@@ -1973,7 +2005,15 @@ class Asset_administration_shell(Identifiable, Has_data_specification):
         self.submodels = submodels
 
 
+# fmt: off
+@invariant(
+    lambda self:
+    not (self.specific_asset_ids is not None)
+    or len(self.specific_asset_ids) > 0,
+    "Specific asset IDs must be either null or have at least one item"
+)
 @reference_in_the_book(section=(5, 7, 4), index=0)
+# fmt: on
 class Asset_information(DBC):
     """
     In :class:`.Asset_information` identifying meta data of the asset that is
@@ -2175,6 +2215,12 @@ class Specific_asset_id(Has_semantics):
         for element in self.submodel_elements
     ),
     "ID-shorts need to be defined for all the submodel elements."
+)
+@invariant(
+    lambda self:
+    not (self.submodel_elements is not None)
+    or len(self.submodel_elements) > 0,
+    "Submodel elements must be either null or have at least one item"
 )
 # fmt: on
 class Submodel(
@@ -3103,7 +3149,15 @@ class File(Data_element):
         self.value = value
 
 
+# fmt: off
+@invariant(
+    lambda self:
+    not (self.annotations is not None)
+    or len(self.annotations) > 0,
+    "Annotations must be either null or have at least one item"
+)
 @reference_in_the_book(section=(5, 7, 7, 1))
+# fmt: on
 class Annotated_relationship_element(Relationship_element):
     """
     An annotated relationship element is a relationship element that can be annotated
@@ -3199,6 +3253,12 @@ class Entity_type(Enum):
     "Constraint AASd-014: Either the attribute global asset ID or "
     "specific asset ID must be set if entity type is set to 'SelfManagedEntity'. "
     "They are not existing otherwise."
+)
+@invariant(
+    lambda self:
+    not (self.statements is not None)
+    or len(self.statements) > 0,
+    "Statements must be either null or have at least one item"
 )
 # fmt: on
 class Entity(Submodel_element):
@@ -3590,7 +3650,27 @@ class Basic_event_element(Event_element):
         self.max_interval = max_interval
 
 
+# fmt: off
+@invariant(
+    lambda self:
+    not (self.inoutput_variables is not None)
+    or len(self.inoutput_variables) > 0,
+    "Inoutput variables must be either null or have at least one item"
+)
+@invariant(
+    lambda self:
+    not (self.output_variables is not None)
+    or len(self.output_variables) > 0,
+    "Output variables must be either null or have at least one item"
+)
+@invariant(
+    lambda self:
+    not (self.input_variables is not None)
+    or len(self.input_variables) > 0,
+    "Input variables must be either null or have at least one item"
+)
 @reference_in_the_book(section=(5, 7, 7, 10))
+# fmt: on
 class Operation(Submodel_element):
     """
     An operation is a submodel element with input and output variables.
@@ -3741,6 +3821,12 @@ Categories for :class:.Concept_description` as defined in :constraintref:`AASd-0
     "the following categories: 'VALUE', 'PROPERTY', 'REFERENCE', 'DOCUMENT', "
     "'CAPABILITY',; 'RELATIONSHIP', 'COLLECTION', 'FUNCTION', 'EVENT', 'ENTITY', "
     "'APPLICATION_CLASS', 'QUALIFIER', 'VIEW'.")
+@invariant(
+    lambda self:
+    not (self.is_case_of is not None)
+    or len(self.is_case_of) > 0,
+    "Is-case-of must be either null or have at least one item"
+)
 # fmt: on
 class Concept_description(Identifiable, Has_data_specification):
     """
@@ -4399,7 +4485,27 @@ class Lang_string_set(DBC):
         self.lang_strings = lang_strings
 
 
+# fmt: off
+@invariant(
+    lambda self:
+    not (self.asset_administration_shells is not None)
+    or len(self.asset_administration_shells) > 0,
+    "Asset administration shells must be either null or have at least one item"
+)
+@invariant(
+    lambda self:
+    not (self.submodels is not None)
+    or len(self.submodels) > 0,
+    "Submodels must be either null or have at least one item"
+)
+@invariant(
+    lambda self:
+    not (self.concept_descriptions is not None)
+    or len(self.concept_descriptions) > 0,
+    "Concept descriptions must be either null or have at least one item"
+)
 @reference_in_the_book(section=(5, 7, 9))
+# fmt: on
 class Environment:
     """
     Container for the sets of different identifiables.

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,127 @@
+"""Provide common functionalities used across the tests."""
+import io
+import pathlib
+from typing import Tuple, MutableMapping
+
+import aas_core_codegen.common
+import aas_core_codegen.parse
+import aas_core_codegen.run
+from aas_core_codegen import intermediate, infer_for_schema
+
+
+def load_symbol_table_and_infer_constraints_for_schema(
+    model_path: pathlib.Path,
+) -> Tuple[
+    intermediate.SymbolTable,
+    MutableMapping[intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty],
+]:
+    """
+    Load the symbol table from the meta-model and infer the schema constraints.
+
+    These constraints might not be sufficient to generate *some* of the instances.
+    Further constraints in form of invariants might apply which are not represented
+    in the schema constraints. However, this will help us cover *many* classes of the
+    meta-model and spare us the work of manually writing many generators.
+    """
+    assert model_path.exists() and model_path.is_file(), model_path
+
+    text = model_path.read_text(encoding="utf-8")
+
+    atok, parse_exception = aas_core_codegen.parse.source_to_atok(source=text)
+    if parse_exception:
+        if isinstance(parse_exception, SyntaxError):
+            raise RuntimeError(
+                f"Failed to parse the meta-model {model_path}: "
+                f"invalid syntax at line {parse_exception.lineno}\n"
+            )
+        else:
+            raise RuntimeError(
+                f"Failed to parse the meta-model {model_path}: " f"{parse_exception}\n"
+            )
+
+    assert atok is not None
+
+    import_errors = aas_core_codegen.parse.check_expected_imports(atok=atok)
+    if import_errors:
+        writer = io.StringIO()
+        aas_core_codegen.run.write_error_report(
+            message="One or more unexpected imports in the meta-model",
+            errors=import_errors,
+            stderr=writer,
+        )
+
+        raise RuntimeError(writer.getvalue())
+
+    lineno_columner = aas_core_codegen.common.LinenoColumner(atok=atok)
+
+    parsed_symbol_table, error = aas_core_codegen.parse.atok_to_symbol_table(atok=atok)
+    if error is not None:
+        writer = io.StringIO()
+        aas_core_codegen.run.write_error_report(
+            message=f"Failed to construct the symbol table from {model_path}",
+            errors=[lineno_columner.error_message(error)],
+            stderr=writer,
+        )
+
+        raise RuntimeError(writer.getvalue())
+
+    assert parsed_symbol_table is not None
+
+    ir_symbol_table, error = intermediate.translate(
+        parsed_symbol_table=parsed_symbol_table,
+        atok=atok,
+    )
+    if error is not None:
+        writer = io.StringIO()
+        aas_core_codegen.run.write_error_report(
+            message=f"Failed to translate the parsed symbol table "
+            f"to intermediate symbol table "
+            f"based on {model_path}",
+            errors=[lineno_columner.error_message(error)],
+            stderr=writer,
+        )
+
+        raise RuntimeError(writer.getvalue())
+
+    assert ir_symbol_table is not None
+
+    (
+        constraints_by_class,
+        inference_errors,
+    ) = aas_core_codegen.infer_for_schema.infer_constraints_by_class(
+        symbol_table=ir_symbol_table
+    )
+
+    if inference_errors is not None:
+        writer = io.StringIO()
+        aas_core_codegen.run.write_error_report(
+            message=f"Failed to infer the constraints for the schema "
+            f"based on {model_path}",
+            errors=[lineno_columner.error_message(error) for error in inference_errors],
+            stderr=writer,
+        )
+
+        raise RuntimeError(writer.getvalue())
+
+    assert constraints_by_class is not None
+    (
+        constraints_by_class,
+        merge_error,
+    ) = aas_core_codegen.infer_for_schema.merge_constraints_with_ancestors(
+        symbol_table=ir_symbol_table, constraints_by_class=constraints_by_class
+    )
+
+    if merge_error is not None:
+        writer = io.StringIO()
+        aas_core_codegen.run.write_error_report(
+            message=f"Failed to infer the constraints for the schema "
+            f"based on {model_path}",
+            errors=[lineno_columner.error_message(merge_error)],
+            stderr=writer,
+        )
+
+        raise RuntimeError(writer.getvalue())
+
+    assert constraints_by_class is not None
+
+    return ir_symbol_table, constraints_by_class


### PR DESCRIPTION
We add an assertion in the tests to check that we infer the minimum
length for all the lists to be 1 except for lists where the end user
defines the semantic (*i.e.*, `Submodel_element_list` and
`Submodel_element_collection`).

This change is necessary so that we avoid ambiguity for the end users
since the distinction in semantics of a null list and an empty list is
not well-defined.