### PR TITLE
Refactor tests to use aas-core-codegen

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "dev": [
             "black==22.3.0",
             "mypy==0.910",
-            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@dac0ca1#egg=aas-core-codegen",
+            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@a08a1eb#egg=aas-core-codegen",
             "astpretty==3.0.0"
         ],
     },

--- a/tests/common.py
+++ b/tests/common.py
@@ -6,12 +6,14 @@ from typing import Tuple, MutableMapping
 import aas_core_codegen.common
 import aas_core_codegen.parse
 import aas_core_codegen.run
+import asttokens
 from aas_core_codegen import intermediate, infer_for_schema
 
 
-def load_symbol_table_and_infer_constraints_for_schema(
+def load_atok_symbol_table_and_infer_constraints_for_schema(
     model_path: pathlib.Path,
 ) -> Tuple[
+    asttokens.ASTTokens,
     intermediate.SymbolTable,
     MutableMapping[intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty],
 ]:
@@ -124,4 +126,4 @@ def load_symbol_table_and_infer_constraints_for_schema(
 
     assert constraints_by_class is not None
 
-    return ir_symbol_table, constraints_by_class
+    return atok, ir_symbol_table, constraints_by_class


### PR DESCRIPTION
Previously, we used Python ``inspect`` to iterate over the symbols in
the aas-core-meta in the tests. This is cumbersome and misses a lot of
edge cases.

Therefore, we leverage aas-core-codegen, parse the model into the
intermediate representation and perform checks on the intermediate
representation instead.