### PR TITLE
Update to aas-core-codegen b8e378f

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
             "black==22.3.0",
             "mypy==0.910",
             "asttokens>=2.0.8,<3",
-            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@a08a1eb#egg=aas-core-codegen",
+            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@b8e378f#egg=aas-core-codegen",
             "astpretty==3.0.0"
         ],
     },


### PR DESCRIPTION
We update to [aas-core-codegen b8e378f] so that the continuous
integration forces all invariants to have a description.

[aas-core-codegen b8e378f]: https://github.com/aas-core-works/aas-core-codegen/commit/b8e378f