### PR TITLE
Re-introduce the pattern for date/time stamps UTC

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -1226,6 +1226,11 @@ class Non_empty_string(str, DBC):
     lambda self: is_xs_date_time_stamp_utc(self),
     "The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.",
 )
+@invariant(
+    lambda self: matches_xs_date_time_stamp_utc(self),
+    "The value must match the pattern of xs:dateTimeStamp with the time zone fixed "
+    "to UTC.",
+)
 class Date_time_stamp_UTC(str, DBC):
     """Represent an ``xs:dateTimeStamp`` with the time zone fixed to UTC."""
 

--- a/additional-verbs-in-imperative-mood.txt
+++ b/additional-verbs-in-imperative-mood.txt
@@ -22,6 +22,7 @@ invert
 log
 re-do
 re-enable
+re-introduce
 re-order
 re-wrap
 redirect


### PR DESCRIPTION
We removed the invariant on the pattern since it is doubly checked in
the ``matches_xs_date_time_stamp_utc`` and
``is_xs_date_time_stamp_utc``. However, this was a mistake as we now can
not infer the pattern for the schemas and test generation.

Therefore, we re-introduce the invariant.