### PR TITLE
Enforce min. length on submodel element value

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,4 +1,4 @@
 # Default ignored files
 /shelf/
 /workspace.xml
-/csv-plugin.xml
+csv-plugin.xml

--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -2552,6 +2552,12 @@ class AAS_submodel_elements(Enum):
     "Constraint AASd-107: If a first level child element has a semantic ID "
     "it shall be identical to semantic ID list element."
 )
+@invariant(
+    lambda self:
+    not (self.value is not None)
+    or len(self.value) >= 1,
+    "Value must be either not set or have at least one item"
+)
 # fmt: on
 class Submodel_element_list(Submodel_element):
     """
@@ -2690,6 +2696,12 @@ class Submodel_element_list(Submodel_element):
         for element in self.value
     ),
     "ID-shorts need to be defined for all the elements."
+)
+@invariant(
+    lambda self:
+    not (self.value is not None)
+    or len(self.value) >= 1,
+    "Value must be either not set or have at least one item"
 )
 # fmt: on
 class Submodel_element_collection(Submodel_element):

--- a/tests/test_v3rc2.py
+++ b/tests/test_v3rc2.py
@@ -1439,18 +1439,6 @@ not (self.qualifiers is not None)
             constraints_by_prop = constraints_by_class.get(our_type, None)
 
             for prop in our_type.properties:
-                # NOTE (mristin, 2022-08-19):
-                # The following properties are exception to the rule as it is
-                # the end user who defines their semantics and not us.
-
-                if (
-                    our_type.name == "Submodel_element_list" and prop.name == "value"
-                ) or (
-                    our_type.name == "Submodel_element_collection"
-                    and prop.name == "value"
-                ):
-                    continue
-
                 if isinstance(
                     intermediate.beneath_optional(prop.type_annotation),
                     intermediate.ListTypeAnnotation,


### PR DESCRIPTION
Originally, we left out the constraint on
``Submodel_element_list.value`` and
``Submodel_element_collection.value`` related to the length as we wanted
to allow the distinction between null lists and empty lists, which the
user could define per semantic ID.

However, this is problematic as many users are not aware of the
distinction. Therefore, we keep consistency with all the other lists in
the meta-model.