### PR TITLE
Reference properties from interfaces

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -2568,18 +2568,18 @@ class Submodel_element_list(Submodel_element):
     :constraint AASd-107:
 
         If a first level child element in a :class:`.Submodel_element_list` has
-        a :attr:`~Submodel_element.semantic_id` it
+        a :attr:`~Has_semantics.semantic_id` it
         shall be identical to :attr:`~Submodel_element_list.semantic_id_list_element`.
 
     :constraint AASd-114:
 
         If two first level child elements in a :class:`.Submodel_element_list` have
-        a :attr:`~Submodel_element.semantic_id` then they shall be identical.
+        a :attr:`~Has_semantics.semantic_id` then they shall be identical.
 
     :constraint AASd-115:
 
         If a first level child element in a :class:`.Submodel_element_list` does not
-        specify a :attr:`~Submodel_element.semantic_id` then the value is assumed to be
+        specify a :attr:`~Has_semantics.semantic_id` then the value is assumed to be
         identical to :attr:`~Submodel_element_list.semantic_id_list_element`.
 
     :constraint AASd-108:
@@ -2782,8 +2782,8 @@ class Data_element(Submodel_element):
 
     :constraint AASd-090:
 
-        For data elements :attr:`~category` (inherited by :class:`.Referable`) shall be
-        one of the following values: ``CONSTANT``, ``PARAMETER`` or ``VARIABLE``.
+        For data elements :attr:`~category` shall be one of the following
+        values: ``CONSTANT``, ``PARAMETER`` or ``VARIABLE``.
 
         Default: ``VARIABLE``
     """


### PR DESCRIPTION
So far, we referenced the properties as properties of a concrete class
in the documentation instead of referencing them to the most abstract
class which defines them.

This creates problems with [docfx] in C# so we reference the
properties as properties of the abstract class.

[docfx]: https://dotnet.github.io/docfx/index.html