### PR TITLE
Change XML namespace to a conventional one

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -90,7 +90,7 @@ __book_url__ = (
 )
 __book_version__ = "V3.0RC02"
 
-__xml_namespace__ = "http://www.admin-shell.io/aas/3/0/RC02"
+__xml_namespace__ = "https://admin-shell.io/aas/3/0/RC02"
 
 # region Verification
 


### PR DESCRIPTION
We strip the subdomain and add the HTTPS protocol to follow the
conventions.

See the issue: https://github.com/admin-shell-io/aas-specs/issues/75