### PR TITLE
Fix casing of some enumeration literals

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -3430,12 +3430,12 @@ class Direction(Enum):
     Direction
     """
 
-    Input = "INPUT"
+    Input = "input"
     """
     Input direction.
     """
 
-    Output = "OUTPUT"
+    Output = "output"
     """
     Output direction
     """
@@ -3447,12 +3447,12 @@ class State_of_event(Enum):
     State of an event
     """
 
-    On = "ON"
+    On = "on"
     """
     Event is on
     """
 
-    Off = "OFF"
+    Off = "off"
     """
     Event is off.
     """


### PR DESCRIPTION
We fix the casing of the enumeration literals ``Direction`` and
``State_of_event``. We transcribed the upper case from the book by
mistake.

This was the original issue:
https://github.com/admin-shell-io/aas-specs/issues/214