### PR TITLE
Fix wrong case in ``xs:NonNegativeInteger``

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -4829,7 +4829,7 @@ class Data_type_def_XSD(Enum):
     Int = "xs:int"
     Short = "xs:short"
     Byte = "xs:byte"
-    Non_negative_integer = "xs:NonNegativeInteger"
+    Non_negative_integer = "xs:nonNegativeInteger"
     Positive_integer = "xs:positiveInteger"
     Unsigned_long = "xs:unsignedLong"
     Unsigned_int = "xs:unsignedInt"


### PR DESCRIPTION
In the V3RC02, we mistakenly capitalized the data type, where it should
have been named ``xs:nonNegativeInteger`` (lowercase first).