### PR TITLE
Fix pattern for ``xs:float`` and ``xs:double``

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -557,7 +557,7 @@ def matches_xs_double(text: str) -> bool:
     # NOTE (mristin, 2022-04-6):
     # See: https://www.w3.org/TR/xmlschema11-2/#nt-doubleRep
     double_rep = (
-        r"(\+|-)?([0-9]+(\.[0-9]*)?|\.[0-9]+)([Ee](\+|-)?[0-9]+)?|(\+|-)?INF|NaN"
+        r"((\+|-)?([0-9]+(\.[0-9]*)?|\.[0-9]+)([Ee](\+|-)?[0-9]+)?|(\+|-)?INF|NaN)"
     )
 
     pattern = f"^{double_rep}$"
@@ -613,7 +613,7 @@ def matches_xs_float(text: str) -> bool:
     :returns: True if the :paramref:`text` conforms to the pattern
     """
     float_rep = (
-        r"(\+|-)?([0-9]+(\.[0-9]*)?|\.[0-9]+)([Ee](\+|-)?[0-9]+)?" r"|(\+|-)?INF|NaN"
+        r"((\+|-)?([0-9]+(\.[0-9]*)?|\.[0-9]+)([Ee](\+|-)?[0-9]+)?" r"|(\+|-)?INF|NaN)"
     )
 
     pattern = f"^{float_rep}$"

--- a/tests/test_v3rc2.py
+++ b/tests/test_v3rc2.py
@@ -297,12 +297,19 @@ class Test_matches_xs_double(unittest.TestCase):
     def test_double_with_preceding_zeros(self) -> None:
         assert v3rc2.matches_xs_double("0001234.01234")
 
-    def test_double_scientific_notation(self) -> None:
-        assert v3rc2.matches_xs_double("-12.34e5.6")
-        assert v3rc2.matches_xs_double("+12.34e5.6")
-        assert v3rc2.matches_xs_double("12.34e5.6")
-        assert v3rc2.matches_xs_double("12.34e+5.6")
-        assert v3rc2.matches_xs_double("12.34e-5.6")
+    def test_exponent_integer(self) -> None:
+        assert v3rc2.matches_xs_double("-12.34e5")
+        assert v3rc2.matches_xs_double("+12.34e5")
+        assert v3rc2.matches_xs_double("12.34e5")
+        assert v3rc2.matches_xs_double("12.34e+5")
+        assert v3rc2.matches_xs_double("12.34e-5")
+
+    def test_exponent_float(self) -> None:
+        assert not v3rc2.matches_xs_double("-12.34e5.6")
+        assert not v3rc2.matches_xs_double("+12.34e5.6")
+        assert not v3rc2.matches_xs_double("12.34e5.6")
+        assert not v3rc2.matches_xs_double("12.34e+5.6")
+        assert not v3rc2.matches_xs_double("12.34e-5.6")
 
     def test_edge_cases(self) -> None:
         assert v3rc2.matches_xs_double("+INF")
@@ -372,12 +379,19 @@ class Test_matches_xs_float(unittest.TestCase):
     def test_float_with_preceding_zeros(self) -> None:
         assert v3rc2.matches_xs_float("0001234.01234")
 
-    def test_float_scientific_notation(self) -> None:
-        assert v3rc2.matches_xs_float("-12.34e5.6")
-        assert v3rc2.matches_xs_float("+12.34e5.6")
-        assert v3rc2.matches_xs_float("12.34e5.6")
-        assert v3rc2.matches_xs_float("12.34e+5.6")
-        assert v3rc2.matches_xs_float("12.34e-5.6")
+    def test_exponent_integer(self) -> None:
+        assert v3rc2.matches_xs_float("-12.34e5")
+        assert v3rc2.matches_xs_float("+12.34e5")
+        assert v3rc2.matches_xs_float("12.34e5")
+        assert v3rc2.matches_xs_float("12.34e+5")
+        assert v3rc2.matches_xs_float("12.34e-5")
+
+    def test_exponent_float(self) -> None:
+        assert not v3rc2.matches_xs_float("-12.34e5.6")
+        assert not v3rc2.matches_xs_float("+12.34e5.6")
+        assert not v3rc2.matches_xs_float("12.34e5.6")
+        assert not v3rc2.matches_xs_float("12.34e+5.6")
+        assert not v3rc2.matches_xs_float("12.34e-5.6")
 
     def test_edge_cases(self) -> None:
         assert v3rc2.matches_xs_float("+INF")


### PR DESCRIPTION
We fix the pattern in V3RC02 for ``xs:float`` and ``xs:double`` as the previous pattern allowed for partial matches and non-integer exponents.