### PR TITLE
Disallow positive-signed `xs:float` and `xs:double`

### DIFF
--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -556,9 +556,7 @@ def matches_xs_double(text: str) -> bool:
     """
     # NOTE (mristin, 2022-04-6):
     # See: https://www.w3.org/TR/xmlschema11-2/#nt-doubleRep
-    double_rep = (
-        r"((\+|-)?([0-9]+(\.[0-9]*)?|\.[0-9]+)([Ee](\+|-)?[0-9]+)?|(\+|-)?INF|NaN)"
-    )
+    double_rep = r"((\+|-)?([0-9]+(\.[0-9]*)?|\.[0-9]+)([Ee](\+|-)?[0-9]+)?|-?INF|NaN)"
 
     pattern = f"^{double_rep}$"
     return match(pattern, text) is not None
@@ -613,7 +611,7 @@ def matches_xs_float(text: str) -> bool:
     :returns: True if the :paramref:`text` conforms to the pattern
     """
     float_rep = (
-        r"((\+|-)?([0-9]+(\.[0-9]*)?|\.[0-9]+)([Ee](\+|-)?[0-9]+)?" r"|(\+|-)?INF|NaN)"
+        r"((\+|-)?([0-9]+(\.[0-9]*)?|\.[0-9]+)([Ee](\+|-)?[0-9]+)?" r"|-?INF|NaN)"
     )
 
     pattern = f"^{float_rep}$"

--- a/tests/test_v3rc2.py
+++ b/tests/test_v3rc2.py
@@ -312,7 +312,9 @@ class Test_matches_xs_double(unittest.TestCase):
         assert not v3rc2.matches_xs_double("12.34e-5.6")
 
     def test_edge_cases(self) -> None:
-        assert v3rc2.matches_xs_double("+INF")
+        # NOTE (mristin, 2022-10-30):
+        # See: https://www.oreilly.com/library/view/xml-schema/0596002521/re67.html
+        assert not v3rc2.matches_xs_double("+INF")
         assert v3rc2.matches_xs_double("-INF")
         assert v3rc2.matches_xs_double("INF")
         assert v3rc2.matches_xs_double("NaN")
@@ -394,7 +396,9 @@ class Test_matches_xs_float(unittest.TestCase):
         assert not v3rc2.matches_xs_float("12.34e-5.6")
 
     def test_edge_cases(self) -> None:
-        assert v3rc2.matches_xs_float("+INF")
+        # NOTE (mristin, 2022-10-30):
+        # See: https://www.oreilly.com/library/view/xml-schema/0596002521/re67.html
+        assert not v3rc2.matches_xs_float("+INF")
         assert v3rc2.matches_xs_float("-INF")
         assert v3rc2.matches_xs_float("INF")
         assert v3rc2.matches_xs_float("NaN")


### PR DESCRIPTION
We disallow the positive sign in front of ``xs:float`` and ``xs:double`` as they are not part of the valid lexical representation.

See also [1] for more details.

[1]: https://www.oreilly.com/library/view/xml-schema/0596002521/re67.html