### PR TITLE
Remove constraints AASd 50 and 50b in V3

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -60,11 +60,6 @@ The working group decided to change the rules for serialization *after* the book
 published. The data specifications are critical in applications, but there is no
 possibility to access them through a data channel as they are not part of
 an environment.
-
-Since the data specifications are now embedded, the following constraints became futile:
-
-* ``AASd-050``
-* ``AASd-050b``
 """
 
 from enum import Enum


### PR DESCRIPTION
The constraints AASd 50 and 50b have been removed in V3, and we propagate the changes to our meta-model.