### PR TITLE
Rename "modeling" to "modelling" in V3

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -1675,7 +1675,7 @@ class Identifiable(Referable):
 
 
 @reference_in_the_book(section=(5, 7, 2, 4), index=1)
-class Modeling_kind(Enum):
+class Modelling_kind(Enum):
     """Enumeration for denoting whether an element is a template or an instance."""
 
     Template = "Template"
@@ -1714,20 +1714,20 @@ class Has_kind(DBC):
     Default for an element is that it is representing an instance.
     """
 
-    kind: Optional["Modeling_kind"]
+    kind: Optional["Modelling_kind"]
     """
     Kind of the element: either type or instance.
 
-    Default: :attr:`Modeling_kind.Instance`
+    Default: :attr:`Modelling_kind.Instance`
     """
 
     @implementation_specific
-    def kind_or_default(self) -> "Modeling_kind":
+    def kind_or_default(self) -> "Modelling_kind":
         # NOTE (mristin, 2022-04-7):
         # This implementation will not be transpiled, but is given here as reference.
-        return self.kind if self.kind is not None else Modeling_kind.Instance
+        return self.kind if self.kind is not None else Modelling_kind.Instance
 
-    def __init__(self, kind: Optional["Modeling_kind"] = None) -> None:
+    def __init__(self, kind: Optional["Modelling_kind"] = None) -> None:
         self.kind = kind
 
 
@@ -1875,7 +1875,7 @@ class Qualifiable(DBC):
         If any :attr:`Qualifier.kind` value of :attr:`Qualifiable.qualifiers` is
         equal to :attr:`Qualifier_kind.Template_qualifier` and the qualified element
         inherits from :class:`Has_kind` then the qualified element shall be of
-        kind Template (:attr:`Has_kind.kind` = :attr:`Modeling_kind.Template`).
+        kind Template (:attr:`Has_kind.kind` = :attr:`Modelling_kind.Template`).
     """
 
     qualifiers: Optional[List["Qualifier"]]
@@ -1908,7 +1908,7 @@ class Qualifier_kind(Enum):
     qualifies the value of the element and can change during run-time.
 
     Value qualifiers are only applicable to elements with kind
-    :attr:`Modeling_kind.Instance`.
+    :attr:`Modelling_kind.Instance`.
     """
 
     Concept_qualifier = "ConceptQualifier"
@@ -1922,7 +1922,7 @@ class Qualifier_kind(Enum):
     qualifies the elements within a specific submodel on concept level.
 
     Template qualifiers are only applicable to elements with kind
-    :attr:`Modeling_kind.Template`.
+    :attr:`Modelling_kind.Template`.
     """
 
 
@@ -2315,7 +2315,7 @@ class Specific_asset_id(Has_semantics):
             qualifier.kind == Qualifier_kind.Template_qualifier
             for qualifier in self.qualifiers
         ) or (
-            self.kind_or_default() == Modeling_kind.Template
+            self.kind_or_default() == Modelling_kind.Template
         )
     ),
     "Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is "
@@ -2325,7 +2325,7 @@ class Specific_asset_id(Has_semantics):
 @invariant(
     lambda self:
     not (self.submodel_elements is not None)
-    or not (self.kind == Modeling_kind.Template)
+    or not (self.kind == Modelling_kind.Template)
     or (
         not any(
             qualifier.kind == Qualifier_kind.Template_qualifier
@@ -2385,7 +2385,7 @@ class Submodel(
         display_name: Optional[List["Lang_string_name_type"]] = None,
         description: Optional[List["Lang_string_text_type"]] = None,
         administration: Optional["Administrative_information"] = None,
-        kind: Optional["Modeling_kind"] = None,
+        kind: Optional["Modelling_kind"] = None,
         semantic_id: Optional["Reference"] = None,
         supplemental_semantic_ids: Optional[List["Reference"]] = None,
         qualifiers: Optional[List["Qualifier"]] = None,
@@ -2432,7 +2432,7 @@ class Submodel(
             qualifier.kind == Qualifier_kind.Template_qualifier
             for qualifier in self.qualifiers
         ) or (
-            self.kind_or_default() == Modeling_kind.Template
+            self.kind_or_default() == Modelling_kind.Template
         )
     ),
     "Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is "

--- a/tests/test_v3.py
+++ b/tests/test_v3.py
@@ -1237,7 +1237,7 @@ not (self.qualifiers is not None)
             qualifier.kind == Qualifier_kind.Template_qualifier
             for qualifier in self.qualifiers
         ) or (
-            self.kind_or_default() == Modeling_kind.Template
+            self.kind_or_default() == Modelling_kind.Template
         )
     )"""
 


### PR DESCRIPTION
We write "modelling" instead of "modeling" to reflect the changes in the book.