### PR TITLE
Fix URL to BCP 47 in the docs of V3

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -1272,7 +1272,7 @@ class BCP_47_language_tag(str, DBC):
     """
     Represent a language tag conformant to BCP 47.
 
-    See: https://en.wikipedia.org/wiki/IETF_language_tag
+    See: https://tools.ietf.org/rfc/bcp/bcp47.txt
     """
 
 


### PR DESCRIPTION
We fix the URL to point to IETF instead of Wikipedia, as it is more precise.