### PR TITLE
Make `refers_to` a list in V3

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -1425,6 +1425,12 @@ class Has_semantics(DBC):
     ),
     "The value must match the value type."
 )
+@invariant(
+    lambda self:
+    not (self.refers_to is not None)
+    or len(self.refers_to) >= 1,
+    "Refers-to must be either not set or have at least one item"
+)
 # fmt: on
 @reference_in_the_book(section=(5, 7, 2, 1), index=1)
 class Extension(Has_semantics):
@@ -1462,7 +1468,7 @@ class Extension(Has_semantics):
     Value of the extension
     """
 
-    refers_to: Optional["Reference"]
+    refers_to: Optional[List["Reference"]]
     """
     Reference to an element the extension refers to.
     """
@@ -1474,7 +1480,7 @@ class Extension(Has_semantics):
             supplemental_semantic_ids: Optional[List["Reference"]] = None,
             value_type: Optional["Data_type_def_XSD"] = None,
             value: Optional["Value_data_type"] = None,
-            refers_to: Optional["Reference"] = None,
+            refers_to: Optional[List["Reference"]] = None,
     ) -> None:
         Has_semantics.__init__(
             self,

--- a/tests/test_v3.py
+++ b/tests/test_v3.py
@@ -1042,6 +1042,7 @@ class Test_assertions(unittest.TestCase):
             "Concept_description.is_case_of",
             "Submodel_element_collection.value",
             "Submodel_element_list.value",
+            "Extension.refers_to",
         }
 
         symbol_table = _META_MODEL.symbol_table


### PR DESCRIPTION
The extension's `refers_to` property is made to a list to reflect changes in the book.