### PR TITLE
Fix external *vs* global reference in V3

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -4710,7 +4710,7 @@ assert Key_types.Fragment_reference in Generic_fragment_keys, (
 
 Generic_globally_identifiables: Set[Key_types] = constant_set(
     values=[
-        Key_types.External_reference,
+        Key_types.Global_reference,
     ],
     description="Enumeration of different key value types within a key.",
     reference_in_the_book=reference_in_the_book(section=(5, 7, 10, 3), index=8),
@@ -4809,7 +4809,7 @@ AAS_referables: Set[Key_types] = constant_set(
 
 Globally_identifiables: Set[Key_types] = constant_set(
     values=[
-        Key_types.External_reference,
+        Key_types.Global_reference,
         Key_types.Asset_administration_shell,
         Key_types.Concept_description,
         Key_types.Identifiable,


### PR DESCRIPTION
We mistakenly wrote external references in V3 where global references were appropriate.