### PR TITLE
Fix Qualifiable invariants 

### DIFF
--- a/.idea/aas-core-meta.iml
+++ b/.idea/aas-core-meta.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.9" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+</module>

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -1853,6 +1853,10 @@ class Qualifiable(DBC):
         equal to :attr:`Qualifier_kind.Template_qualifier` and the qualified element
         inherits from :class:`Has_kind` then the qualified element shall be of
         kind Template (:attr:`Has_kind.kind` = :attr:`Modelling_kind.Template`).
+
+    .. note::
+
+        This constraint is checked at :class:`Submodel`.
     """
 
     qualifiers: Optional[List["Qualifier"]]


### PR DESCRIPTION
See #204.

We confused AASd-119 and AASd-129 at several points of aas-core-meta, considering they are similar. This confusion has now been resolved: https://github.com/aas-core-works/aas-core-meta/issues/204#issuecomment-1429287012

Chapter 5.3.12.3, page 112
https://nextcloud.s-heppner.com/index.php/s/2KZr2kHoSTjkSoi#page=112

Now, AASd-129 needs to be fully implemented, before this PR loses WIP status