### PR TITLE
Add documentation for why diverging from the spec at AASd-116

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -24,9 +24,13 @@ such as language understanding, so we could not formalize them:
 
 * :constraintref:`AASd-012`
 
-:constraintref:`AASd-116`: In this constraint the string ``globalAssetId`` is checked case-sensitively,
-as it would be not well defined, which characters would be equal in this kind of check
-otherwise. For example, would the UTF-8 characters U+04E7 and U+00F6 be equal?
+:constraintref:`AASd-116`: In the book, :constraintref:AASd-116 imposes a
+case-insensitive equality against globalAssetId. This is culturally-dependent,
+and depends on the system settings. For example, the case-folding
+for the letters "i" and "I" is different in Turkish from English.
+
+We implement the constraint as case-sensitive instead to allow for interoperability
+across different culture settings.
 
 Furthermore, we diverge from the book in the following points regarding
 the enumerations. We have to implement subsets of enumerations as sets as common

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -2148,7 +2148,7 @@ class Asset_information(DBC):
 
     .. note::
 
-        Constraint AASd-116 is important to enable a generic search across global and
+        :constraintref:`AASd-116` is important to enable a generic search across global and
         specific asset IDs.
 
     .. note::

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -24,7 +24,7 @@ such as language understanding, so we could not formalize them:
 
 * :constraintref:`AASd-012`
 
-:constraintref:`AASd-116`: In the book, :constraintref:AASd-116 imposes a
+In the book, :constraintref:AASd-116 imposes a
 case-insensitive equality against globalAssetId. This is culturally-dependent,
 and depends on the system settings. For example, the case-folding
 for the letters "i" and "I" is different in Turkish from English.

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -24,6 +24,10 @@ such as language understanding, so we could not formalize them:
 
 * :constraintref:`AASd-012`
 
+:constraintref:`AASd-116`: In this constraint the string ``globalAssetId`` is checked case-sensitively,
+as it would be not well defined, which characters would be equal in this kind of check
+otherwise. For example, would the UTF-8 characters U+04E7 and U+00F6 be equal?
+
 Furthermore, we diverge from the book in the following points regarding
 the enumerations. We have to implement subsets of enumerations as sets as common
 programming languages do not support inheritance of enumerations. The relationship
@@ -1161,6 +1165,7 @@ def reference_key_values_equal(that: "Reference", other: "Reference") -> bool:
 
 # endregion
 
+
 # fmt: off
 @invariant(
     lambda self: len(self) >= 1,
@@ -2108,7 +2113,7 @@ class Asset_administration_shell(Identifiable, Has_data_specification):
             for specific_asset_ID in self.specific_asset_IDs
         )
     ),
-    "AASd-116: ``globalAssetId`` is a reserved key. "
+    "Constraint AASd-116: ``globalAssetId`` is a reserved key. "
     "If used as value for ``Specific_asset_ID.name`` then ``Specific_asset_ID.value`` "
     "shall be identical to ``global_asset_ID``."
 )
@@ -2137,6 +2142,19 @@ class Asset_information(DBC):
 
         For AssetInformation either the :attr:`global_asset_ID` shall be defined
         or at least one specificAssetId.
+
+    .. note::
+
+        Constraint AASd-116 is important to enable a generic search across global and
+        specific asset IDs.
+
+    .. note::
+
+        We diverge from the specification, where ``globalAssetId`` is checked
+        case-insensitive, as it would be not well defined, which characters would be
+        equal in this kind of check. Therefore, here, the string ``globalAssetId``
+        is checked case-sensitively. For example, would the UTF-8 characters
+        U+04E7 and U+00F6 be equal?
     """
 
     asset_kind: "Asset_kind"

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -2117,8 +2117,8 @@ class Asset_administration_shell(Identifiable, Has_data_specification):
         )
     ),
     "Constraint AASd-116: ``globalAssetId`` is a reserved key. "
-    "If used as value for ``Specific_asset_ID.name`` then ``Specific_asset_ID.value`` "
-    "shall be identical to ``global_asset_ID``."
+    "If used as value for the name of specific asset ID then the value of specific asset ID "
+    "shall be identical to the global asset ID."
 )
 @reference_in_the_book(section=(5, 7, 4), index=0)
 # fmt: on

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -2161,8 +2161,8 @@ class Asset_administration_shell(Identifiable, Has_data_specification):
         )
     ),
     "Constraint AASd-116: ``globalAssetId`` is a reserved key. "
-    "If used as value for the name of specific asset ID then the value of specific asset ID "
-    "shall be identical to the global asset ID."
+    "If used as value for the name of specific asset ID then the value of specific "
+    "asset ID shall be identical to the global asset ID."
 )
 @reference_in_the_book(section=(5, 3, 4), index=0)
 # fmt: on
@@ -2197,14 +2197,14 @@ class Asset_information(DBC):
 
     .. note::
 
-		In the book, :constraintref:`AASd-116` imposes a
-		case-insensitive equality against globalAssetId. This is 
-		culturally-dependent, and depends on the system settings. 
-		For example, the case-folding for the letters "i" and "I" is 
-		different in Turkish from English.
+        In the book, :constraintref:`AASd-116` imposes a
+        case-insensitive equality against globalAssetId. This is
+        culturally-dependent, and depends on the system settings.
+        For example, the case-folding for the letters "i" and "I" is
+        different in Turkish from English.
 
-		We implement the constraint as case-sensitive instead to allow 
-		for interoperability across different culture settings.
+        We implement the constraint as case-sensitive instead to allow
+        for interoperability across different culture settings.
     """
 
     asset_kind: "Asset_kind"

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -2153,11 +2153,14 @@ class Asset_information(DBC):
 
     .. note::
 
-        We diverge from the specification, where ``globalAssetId`` is checked
-        case-insensitive, as it would be not well defined, which characters would be
-        equal in this kind of check. Therefore, here, the string ``globalAssetId``
-        is checked case-sensitively. For example, would the UTF-8 characters
-        U+04E7 and U+00F6 be equal?
+		In the book, :constraintref:`AASd-116` imposes a
+		case-insensitive equality against globalAssetId. This is 
+		culturally-dependent, and depends on the system settings. 
+		For example, the case-folding for the letters "i" and "I" is 
+		different in Turkish from English.
+
+		We implement the constraint as case-sensitive instead to allow 
+		for interoperability across different culture settings.
     """
 
     asset_kind: "Asset_kind"

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -23,14 +23,13 @@ Some constraints are not enforceable as they depend on the wider context
 such as language understanding, so we could not formalize them:
 
 * :constraintref:`AASd-012`
+* :constraintref:`AASd-116`: In the book, :constraintref:`AASd-116` imposes a
+  case-insensitive equality against globalAssetId. This is culturally-dependent,
+  and depends on the system settings. For example, the case-folding
+  for the letters "i" and "I" is different in Turkish from English.
 
-In the book, :constraintref:AASd-116 imposes a
-case-insensitive equality against globalAssetId. This is culturally-dependent,
-and depends on the system settings. For example, the case-folding
-for the letters "i" and "I" is different in Turkish from English.
-
-We implement the constraint as case-sensitive instead to allow for interoperability
-across different culture settings.
+  We implement the constraint as case-sensitive instead to allow for interoperability
+  across different culture settings.
 
 Furthermore, we diverge from the book in the following points regarding
 the enumerations. We have to implement subsets of enumerations as sets as common

--- a/htmlgen/for_metamodel.py
+++ b/htmlgen/for_metamodel.py
@@ -1062,8 +1062,6 @@ def _generate_page_for_class(
             )
         )
 
-    print(f"cls.name is {cls.name!r}")  # TODO: debug
-    print(f"cls.concrete_descendants is {cls.concrete_descendants!r}")  # TODO: debug
     if len(cls.concrete_descendants) > 0:
         li_descendants = [
             f"""\


### PR DESCRIPTION
(case insensitive checking of string) 
See #205

AASd-116 
> "globalAssetId" (case-insensitive) is a reserved key. If used as value for SpecificAssetId/name, SpecificAssetId/value shall be identical to AssetInformation/globalAssetId.
> Note: AASd-116 is important to enable a generic search across global and specific asset IDs.

(Chapter 5.3.12.5, page 112)
https://nextcloud.s-heppner.com/index.php/s/2KZr2kHoSTjkSoi#page=112

AASd-116 asks for case-insensitive checking of the key "globalAssetId". We diverge from this and write an explanation as to why. 

