### PR TITLE
Change type of Data_spec_IEC.value

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -1161,6 +1161,7 @@ def reference_key_values_equal(that: "Reference", other: "Reference") -> bool:
 
 # endregion
 
+
 # fmt: off
 @invariant(
     lambda self: len(self) >= 1,
@@ -5462,6 +5463,18 @@ def is_BCP_47_for_english(text: str) -> bool:
 )
 @invariant(
     lambda self:
+    not (self.value is not None)
+    or lang_strings_have_unique_languages(self.value),
+    "Value specifies no duplicate languages"
+)
+@invariant(
+    lambda self:
+    not (self.value is not None)
+    or len(self.value) >= 1,
+    "Value must be either not set or have at least one item"
+)
+@invariant(
+    lambda self:
     not (self.definition is not None)
     or lang_strings_have_unique_languages(self.definition),
     "Definition specifies no duplicate languages"
@@ -5621,7 +5634,7 @@ class Data_specification_IEC_61360(Data_specification_content):
     List of allowed values
     """
 
-    value: Optional[str]
+    value: Optional[List[Lang_string_short_name_type_IEC_61360]]
     """
     Value
     """
@@ -5643,7 +5656,7 @@ class Data_specification_IEC_61360(Data_specification_content):
         definition: Optional[List["Lang_string_definition_type_IEC_61360"]] = None,
         value_format: Optional[Non_empty_XML_serializable_string] = None,
         value_list: Optional["Value_list"] = None,
-        value: Optional[str] = None,
+        value: Optional[List[Lang_string_short_name_type_IEC_61360]] = None,
         level_type: Optional["Level_type"] = None,
     ) -> None:
         self.preferred_name = preferred_name

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -1229,7 +1229,7 @@ class Identifier(Non_empty_XML_serializable_string, DBC):
     lambda self: len(self) <= 2000,
     "ValueTypeIec61360 shall have a maximum length of 2000 characters.",
 )
-class Value_type_Iec_61360(Non_empty_XML_serializable_string, DBC):
+class Value_type_IEC_61360(Non_empty_XML_serializable_string, DBC):
     """
     string
     """
@@ -5644,7 +5644,7 @@ class Data_specification_IEC_61360(Data_specification_content):
     List of allowed values
     """
 
-    value: Optional[Value_type_Iec_61360]
+    value: Optional[Value_type_IEC_61360]
     """
     Value
     """
@@ -5666,7 +5666,7 @@ class Data_specification_IEC_61360(Data_specification_content):
         definition: Optional[List["Lang_string_definition_type_IEC_61360"]] = None,
         value_format: Optional[Non_empty_XML_serializable_string] = None,
         value_list: Optional["Value_list"] = None,
-        value: Optional[Value_type_Iec_61360] = None,
+        value: Optional[Value_type_IEC_61360] = None,
         level_type: Optional["Level_type"] = None,
     ) -> None:
         self.preferred_name = preferred_name

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -1225,7 +1225,6 @@ class Identifier(Non_empty_XML_serializable_string, DBC):
     """
 
 
-@reference_in_the_book(section=(5, 7, 12, 2))
 @invariant(
     lambda self: len(self) <= 2000,
     "ValueTypeIec61360 shall have a maximum length of 2000 characters.",

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -1225,6 +1225,17 @@ class Identifier(Non_empty_XML_serializable_string, DBC):
     """
 
 
+@reference_in_the_book(section=(5, 7, 12, 2))
+@invariant(
+    lambda self: len(self) <= 2000,
+    "ValueTypeIec61360 shall have a maximum length of 2000 characters.",
+)
+class Value_type_Iec_61360(Non_empty_XML_serializable_string, DBC):
+    """
+    string
+    """
+
+
 @reference_in_the_book(section=(5, 3, 11, 2))
 @invariant(
     lambda self: len(self) <= 128,
@@ -5634,7 +5645,7 @@ class Data_specification_IEC_61360(Data_specification_content):
     List of allowed values
     """
 
-    value: Optional[List[Lang_string_short_name_type_IEC_61360]]
+    value: Optional[Value_type_Iec_61360]
     """
     Value
     """
@@ -5656,7 +5667,7 @@ class Data_specification_IEC_61360(Data_specification_content):
         definition: Optional[List["Lang_string_definition_type_IEC_61360"]] = None,
         value_format: Optional[Non_empty_XML_serializable_string] = None,
         value_list: Optional["Value_list"] = None,
-        value: Optional[List[Lang_string_short_name_type_IEC_61360]] = None,
+        value: Optional[Value_type_Iec_61360] = None,
         level_type: Optional["Level_type"] = None,
     ) -> None:
         self.preferred_name = preferred_name


### PR DESCRIPTION
See #209

Equivalently to https://github.com/aas-core-works/aas-core-meta/pull/221, also the type of `Data_specification_iec_61360.value` was changed. `List[Lang_string_short_name_type_IEC_61360]` corresponds to ShortNameTypeIEC61360 in the spec. I'm personally lacking knowledge on DataSpec IEC 61360 to identify if this change makes sense, so I'll take it for granted.

See Part 3a, Chapter 6.2, page 29
https://nextcloud.s-heppner.com/index.php/s/JFHPPSW9D7KtgBC#page=29