### PR TITLE
Adapt types of `Administrative_information` version and revision

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -1771,27 +1771,33 @@ class Has_data_specification(DBC):
 @invariant(
     lambda self:
     not (self.version is not None)
-    or not (len(self.version) > 4)
-    or not (len(self.version) < 1),
+    or (
+            len(self.version) > 0
+            and len(self.version) <= 4
+    ),
     "AdministrativeInformation/version shall have a length of "
     "maximum 4 characters and minimum 1 character."
 )
 @invariant(
     lambda self:
     not (self.revision is not None)
-    or not (len(self.revision) > 4)
-    or not (len(self.revision) < 1),
+    or (
+            len(self.version) > 0
+            and len(self.version) <= 4
+    ),
     "AdministrativeInformation/revision shall have a length of "
     "maximum 4 characters and minimum 1 character."
 )
 @invariant(
     lambda self:
-    matches_version_type(self.version),
+    not (self.version is not None)
+    or matches_version_type(self.version),
     "AdministrativeInformation/version shall be of VersionType"
 )
 @invariant(
     lambda self:
-    matches_revision_type(self.revision),
+    not (self.version is not None)
+    or matches_revision_type(self.revision),
     "AdministrativeInformation/revision shall be of RevisionType"
 )
 @reference_in_the_book(section=(5, 7, 2, 5))

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -91,6 +91,26 @@ def matches_ID_short(text: str) -> bool:
 
 
 @verification
+def matches_version_type(text: str) -> bool:
+    """
+    Check that :paramref:`text` is a valid version string.
+    """
+    pattern = f"/^([0-9]|[1-9][0-9]*)$/"
+
+    return match(pattern, text) is not None
+
+
+@verification
+def matches_revision_type(text: str) -> bool:
+    """
+    Check that :paramref:`text` is a valid revision string.
+    """
+    pattern = f"/^([0-9]|[1-9][0-9]*)$/"
+
+    return match(pattern, text) is not None
+
+
+@verification
 def matches_xs_date_time_UTC(text: str) -> bool:
     """
     Check that :paramref:`text` conforms to the pattern of an ``xs:dateTime``.
@@ -1161,6 +1181,7 @@ def reference_key_values_equal(that: "Reference", other: "Reference") -> bool:
 
 # endregion
 
+
 # fmt: off
 @invariant(
     lambda self: len(self) >= 1,
@@ -1750,16 +1771,28 @@ class Has_data_specification(DBC):
 @invariant(
     lambda self:
     not (self.version is not None)
-    or not (len(self.version) > 4),
-    "Constraint AASd-135: AdministrativeInformation/version shall have a length of "
-    "maximum 4 characters."
+    or not (len(self.version) > 4)
+    or not (len(self.version) < 1),
+    "AdministrativeInformation/version shall have a length of "
+    "maximum 4 characters and minimum 1 character."
 )
 @invariant(
     lambda self:
     not (self.revision is not None)
-    or not (len(self.revision) > 4),
-    "Constraint AASd-136: AdministrativeInformation/revision shall have a length of "
-    "maximum 4 characters."
+    or not (len(self.revision) > 4)
+    or not (len(self.revision) < 1),
+    "AdministrativeInformation/revision shall have a length of "
+    "maximum 4 characters and minimum 1 character."
+)
+@invariant(
+    lambda self:
+    matches_version_type(self.version),
+    "AdministrativeInformation/version shall be of VersionType"
+)
+@invariant(
+    lambda self:
+    matches_revision_type(self.revision),
+    "AdministrativeInformation/revision shall be of RevisionType"
 )
 @reference_in_the_book(section=(5, 7, 2, 5))
 # fmt: on


### PR DESCRIPTION
See #215

Class AdministrativeInformation: Chapter 5.3.2.2, page 55
https://nextcloud.s-heppner.com/index.php/s/2KZr2kHoSTjkSoi#page=55

The new types: Chapter 5.3.11.2, page 103
https://nextcloud.s-heppner.com/index.php/s/2KZr2kHoSTjkSoi#page=103