### PR TITLE
Generate list of concrete descendants in htmlgen

### DIFF
--- a/htmlgen/.gitignore
+++ b/htmlgen/.gitignore
@@ -1,0 +1,2 @@
+html-for-debug
+.html-for-debug

--- a/htmlgen/for_metamodel.py
+++ b/htmlgen/for_metamodel.py
@@ -1062,6 +1062,37 @@ def _generate_page_for_class(
             )
         )
 
+    print(f"cls.name is {cls.name!r}")  # TODO: debug
+    print(f"cls.concrete_descendants is {cls.concrete_descendants!r}")  # TODO: debug
+    if len(cls.concrete_descendants) > 0:
+        li_descendants = [
+            f"""\
+<li>
+{I}<a href="{descendant.name}.html">{descendant.name}</a>
+</li>"""
+            for descendant in cls.concrete_descendants
+        ]
+
+        li_descendants_joined = "\n".join(li_descendants)
+        ul_descendants = Stripped(
+            f"""\
+<ul>
+{I}{indent_but_first_line(li_descendants_joined, I)}
+</ul>"""
+        )
+
+        blocks.append(
+            Stripped(
+                f"""\
+<h2>
+{I}<a name="concrete-descendants"></a>
+{I}Concrete Descendants
+{I}<a class="aas-anchor-link" href="#concrete-descendants">🔗</a>
+</h2>
+{ul_descendants}"""
+            )
+        )
+
     if len(cls.properties) > 0:
         blocks.append(
             Stripped(

--- a/htmlgen/main.py
+++ b/htmlgen/main.py
@@ -185,6 +185,7 @@ def main() -> int:
     parser.add_argument(
         "--html_dir",
         help="path to where the generated HTML will be saved",
+        required=True,
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
It is often very hard to figure out who implements a given parent class, so we list all the concrete descendants in that class page for easier browsing.