### PR TITLE
Add "WIP" to version to avoid confusion

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -85,7 +85,7 @@ from aas_core_meta.marker import (
 )
 
 __book_url__ = "https://to-be-published"
-__book_version__ = "V3.0WIP"
+__book_version__ = "V3.0-work-in-progress"
 
 __xml_namespace__ = "https://admin-shell.io/aas/3/0"
 

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -85,7 +85,7 @@ from aas_core_meta.marker import (
 )
 
 __book_url__ = "https://to-be-published"
-__book_version__ = "V3.0 (Work in Progress)"
+__book_version__ = "V3.0WIP"
 
 __xml_namespace__ = "https://admin-shell.io/aas/3/0"
 

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -85,7 +85,7 @@ from aas_core_meta.marker import (
 )
 
 __book_url__ = "https://to-be-published"
-__book_version__ = "V3.0"
+__book_version__ = "V3.0 (Work in Progress)"
 
 __xml_namespace__ = "https://admin-shell.io/aas/3/0"
 


### PR DESCRIPTION
We add a suffix `-work-in-progress` to let the readers know that this
version of the meta-model is still not complete, and is expected to 
change in the very near future.