### PR TITLE
Highlight separation from IDTA in the docs

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -7,9 +7,9 @@ aas-core-works, which can be found here: https://github.com/aas-core-works.
 The presented content is neither related to the IDTA nor
 Plattform Industrie 4.0 and does not represent an official publication.
 
-We had to diverge from the book in the following points.
+We diverge from the book in the following points.
 
-We could not implement the following constraints as they are too general and can not
+We did not implement the following constraints as they are too general and can not
 be formalized as part of the core library, but affects external components such as
 AAS registry or AAS server:
 
@@ -18,7 +18,7 @@ AAS registry or AAS server:
     :attr:`Referable.ID_short` of non-identifiable referables
     within the same name space shall be unique (case-sensitive).
 
-We could not implement the following constraints since they depend on registry and
+We did not implement the following constraints since they depend on registry and
 de-referencing, so we can not formalize them with formalizing such external
 dependencies:
 

--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -1,9 +1,15 @@
 """
-Provide the meta-model for Asset Administration Shell V3.0 Release Candidate 2.
+Provide an implementation of the Asset Administration Shell V3.0 Release Candidate 2.
 
-We had to diverge from the book in the following points.
+The presented version of the Metamodel is related to the work of
+aas-core-works, which can be found here: https://github.com/aas-core-works.
 
-We could not implement the following constraints as they are too general and can not
+The presented content is neither related to the IDTA nor
+Plattform Industrie 4.0 and does not represent an official publication.
+
+We diverge from the book in the following points.
+
+We did not implement the following constraints as they are too general and can not
 be formalized as part of the core library, but affects external components such as
 AAS registry or AAS server:
 
@@ -16,7 +22,7 @@ AAS registry or AAS server:
 
     :attr:`Referable.id_short` of :class:`Referable`'s shall be matched case-sensitive.
 
-We could not implement the following constraints since they depend on registry and
+We did not implement the following constraints since they depend on registry and
 de-referencing, so we can not formalize them with formalizing such external
 dependencies:
 

--- a/htmlgen/for_metamodel.py
+++ b/htmlgen/for_metamodel.py
@@ -1509,7 +1509,7 @@ def _generate_home_page(
     content = Stripped(
         f"""\
 <h1>
-{I}Meta-model {html.escape(symbol_table.meta_model.book_version)}
+{I}aas-core-meta {html.escape(symbol_table.meta_model.book_version)}
 {I}<a class="aas-anchor-link" href="">🔗</a>
 </h1>
 <div class="aas-description">


### PR DESCRIPTION
While aas-core-meta team works closely with IDTA, it is not *officially*
part of it.

We make this distinction a bit more explicit in the documentation of
the meta-models.