### PR TITLE
[V3] Fix version and revision types

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -108,7 +108,7 @@ def matches_version_type(text: str) -> bool:
     """
     Check that :paramref:`text` is a valid version string.
     """
-    pattern = f"/^([0-9]|[1-9][0-9]*)$/"
+    pattern = f"^(0|[1-9][0-9]*)$"
 
     return match(pattern, text) is not None
 
@@ -118,7 +118,7 @@ def matches_revision_type(text: str) -> bool:
     """
     Check that :paramref:`text` is a valid revision string.
     """
-    pattern = f"/^([0-9]|[1-9][0-9]*)$/"
+    pattern = f"^(0|[1-9][0-9]*)$"
 
     return match(pattern, text) is not None
 


### PR DESCRIPTION
The patterns in version and revision type had slashes as invalid prefixes and suffixes.

This patch fixes the issue.