### PR TITLE
[v3.0] Fix typo in docstring of Administrative_information

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -1848,7 +1848,7 @@ class Administrative_information(Has_data_specification):
     .. note::
 
        In case of a submodel the :attr:`template_ID` is the identifier
-       of the submodel template_ID that guided the creation of the submodel
+       of the submodel template ID that guided the creation of the submodel
 
     .. note::
 


### PR DESCRIPTION
There exists no `submodel template_ID`.
What is meant here is the ID of a submodel template`. This typo is fixed to avoid confusion.