### PR TITLE
[V3] Follow text to re-write logic of AASd-129

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -2410,16 +2410,16 @@ class Specific_asset_ID(Has_semantics):
     lambda self:
     not (self.submodel_elements is not None)
     or (
-        not (self.kind == Modelling_kind.Template)
-        or (
-            not any(
+        not any(
                 not (submodel_element.qualifiers is not None)
-                or not any(
+                or any(
                     qualifier.kind_or_default() == Qualifier_kind.Template_qualifier
                     for qualifier in submodel_element.qualifiers
                 )
                 for submodel_element in self.submodel_elements
             )
+        or (
+            self.kind == Modelling_kind.Template
         )
     ),
     "Constraint AASd-129: If any qualifier kind value of a Submodel element qualifier "


### PR DESCRIPTION
We had another look at the text of the invariant:

> Constraint AASd-129: If any qualifier kind value of a Submodel element
> qualifier is equal to TemplateQualifier then the submodel element shall
> be part of a submodel template, i.e. a Submodel with submodel kind
> value is equal to "Template".

We understand it in a simplified form as follows.
If any qualifier of a submodel element is a template qualifier, then the submodel kind is equal to "Template".

We adapt the logic of the submodel invariant accordingly.