### PR TITLE
Fix invariant for AASd-129

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -2410,16 +2410,16 @@ class Specific_asset_ID(Has_semantics):
     lambda self:
     not (self.submodel_elements is not None)
     or (
-        not any(
+        not (self.kind != Modelling_kind.Template)
+        or (
+            all(
                 not (submodel_element.qualifiers is not None)
-                or any(
-                    qualifier.kind_or_default() == Qualifier_kind.Template_qualifier
+                or all(
+                    qualifier.kind_or_default() != Qualifier_kind.Template_qualifier
                     for qualifier in submodel_element.qualifiers
                 )
                 for submodel_element in self.submodel_elements
             )
-        or (
-            self.kind == Modelling_kind.Template
         )
     ),
     "Constraint AASd-129: If any qualifier kind value of a Submodel element qualifier "


### PR DESCRIPTION
We got the logic wrong in #249. Namely, when a submodel element has no qualifiers, the predicate are still satisfied and imply that the submodel has to be a template.

This patch (hopefully) solves the issue. We tested the logic preliminary on aas-core3.0-testgen and it seems to work.