### PR TITLE
[V3.0] Implement missing constraint logic for AASd-117.

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -1423,7 +1423,7 @@ class ID_short_type(Name_type, DBC):
     .. note::
 
         Due to implementation limitations, this cannot be checked at
-        :class:`ID_short_type` level or at :class:`Referable` s,
+        `ID_short_type` level or at :class:`Referable` s,
         rather it has to be checked at the level of the parent-object
         holding the :class:`Referable` s.
 

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -2084,6 +2084,12 @@ class Qualifier(Has_semantics):
     or len(self.submodels) >= 1,
     "Submodels must be either not set or have at least one item"
 )
+@invariant(
+    lambda self:
+    not (self.ID_short is None),
+    "Constraint AASd-117: ID-short of of Referables not being a direct child of a"
+    "Submodel element list shall be specified"
+)
 # fmt: on
 class Asset_administration_shell(Identifiable, Has_data_specification):
     """An asset administration shell."""
@@ -2391,6 +2397,18 @@ class Specific_asset_ID(Has_semantics):
 
 # fmt: off
 @reference_in_the_book(section=(5, 3, 5))
+@invariant(
+    lambda self:
+    not (self.ID_short is None)
+    and (
+            all(
+                submodel_element.ID_short is not None
+                for submodel_element in self.submodel_elements
+            )
+    ),
+    "Constraint AASd-117: ID-short of of Referables not being a direct child of a"
+    "Submodel element list shall be specified"
+)
 @invariant(
     lambda self:
     not (self.qualifiers is not None)
@@ -2851,6 +2869,17 @@ class Submodel_element_list(Submodel_element):
     not (self.value is not None)
     or len(self.value) >= 1,
     "Value must be either not set or have at least one item"
+)
+@invariant(
+    lambda self:
+    (
+        all(
+            submodel_element.ID_short is not None
+            for submodel_element in self.value
+        )
+    ),
+    "Constraint AASd-117: ID-short of of Referables not being a direct child of a"
+    "Submodel element list shall be specified"
 )
 # fmt: on
 class Submodel_element_collection(Submodel_element):
@@ -4285,6 +4314,12 @@ def data_specification_IEC_61360s_have_definition_at_least_in_english(
     not (self.is_case_of is not None)
     or len(self.is_case_of) >= 1,
     "Is-case-of must be either not set or have at least one item"
+)
+@invariant(
+    lambda self:
+    not (self.ID_short is None),
+    "Constraint AASd-117: ID-short of of Referables not being a direct child of a"
+    "Submodel element list shall be specified"
 )
 # fmt: on
 class Concept_description(Identifiable, Has_data_specification):

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -1420,27 +1420,27 @@ class ID_short_type(Name_type, DBC):
         Constraint AASd-117: idShort of non-identifiable :class:`Referable`
         not being a direct child of a :class:`Submodel_element_list` shall be specified.
 
-    .. Note::
+    .. note::
 
         Due to implementation limitations, this cannot be checked at :class:`ID_short`
         level or at :class:`Referable`s, rather it has to be checked at the level of
         the parent-object holding the :class:`Referable`s.
 
-        * An :class:`Asset_administration_shell`-object can never be a child of a
-          :class:`Submodel_element_list`, therefore check that :class:`ID_short` is set.
+        An :class:`Asset_administration_shell`-object can never be a child of a
+        :class:`Submodel_element_list`, therefore check that :class:`ID_short` is set.
 
-        * A :class:`Submodel`-object can never be a child of a
-          :class:`Submodel_element_list`, as well as its children are not children of
-          :class:`Submodel_element_list`, therefore check that its own :class:`ID_short`
-          as well as its children's :class:`ID_short` is not `None`.
+        A :class:`Submodel`-object can never be a child of a
+        :class:`Submodel_element_list`, as well as its children are not children of
+        :class:`Submodel_element_list`, therefore check that its own :class:`ID_short`
+        as well as its children's :class:`ID_short` is not `None`.
 
-        * A :class:`Submodel_element_collection` can be child of a
-          :class:`Submodel_element_list`, its children cannot, though. Therefore check
-          that its children have :class:`ID_short` set.
+        A :class:`Submodel_element_collection` can be child of a
+        :class:`Submodel_element_list`, its children cannot, though. Therefore check
+        that its children have :class:`ID_short` set.
 
-        * An :class:`Operation_variable` has a :attr:`Operation_variable.value`, that
-          is not child of a :class:`Submodel_element_list`, therefore check that its
-          :class:`ID_short` is not `None`.
+        An :class:`Operation_variable` has a :attr:`Operation_variable.value`, that
+        is not child of a :class:`Submodel_element_list`, therefore check that its
+        :class:`ID_short` is not `None`.
     """
 
 

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -1417,31 +1417,31 @@ class ID_short_type(Name_type, DBC):
 
     :constraint AASd-117:
 
-        Constraint AASd-117: `ID_short` of non-identifiable :class:`Referable`
+        Constraint AASd-117: ID-short of non-identifiable :class:`Referable`
         not being a direct child of a :class:`Submodel_element_list` shall be specified.
 
     .. note::
 
         Due to implementation limitations, this cannot be checked at
-        `ID_short_type` level or at :class:`Referable` s,
+        ID_short_type level or at :class:`Referable` s,
         rather it has to be checked at the level of the parent-object
         holding the :class:`Referable` s.
 
         An :class:`Asset_administration_shell` -object can never be a child of a
-        :class:`Submodel_element_list`, therefore check that `ID_short` is set.
+        :class:`Submodel_element_list`, therefore check that ID-short is set.
 
         A :class:`Submodel`-object can never be a child of a
         :class:`Submodel_element_list` , as well as its children are not children of
-        :class:`Submodel_element_list` , therefore check that its own `ID_short`
-        as well as its children's `ID_short` is not `None`.
+        :class:`Submodel_element_list` , therefore check that its own ID-short
+        as well as its children's ID-short is not `None`.
 
         A :class:`Submodel_element_collection` can be child of a
         :class:`Submodel_element_list` , its children cannot, though. Therefore check
-        that its children have `ID_short` set.
+        that its children have ID-short set.
 
         An :class:`Operation_variable` has a :attr:`Operation_variable.value`, that
         is not child of a :class:`Submodel_element_list` , therefore check that its
-        `ID_short` is not `None`.
+        ID-short is not `None`.
     """
 
 
@@ -1647,7 +1647,7 @@ class Has_extensions(DBC):
 # fmt: on
 class Referable(Has_extensions):
     """
-    An element that is referable by its :attr:`ID_short`.
+    An element that is referable by its :attr:ID-short.
 
     This ID is not globally unique.
     This ID is unique within the name space of the element.
@@ -1678,7 +1678,7 @@ class Referable(Has_extensions):
 
         In case the element is a property and the property has a semantic definition
         (:attr:`Has_semantics.semantic_ID`) conformant to IEC61360
-        the :attr:`ID_short` is typically identical to the short name in English.
+        the :attr:ID-short is typically identical to the short name in English.
     """
 
     display_name: Optional[List["Lang_string_name_type"]]

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -1417,30 +1417,31 @@ class ID_short_type(Name_type, DBC):
 
     :constraint AASd-117:
 
-        Constraint AASd-117: idShort of non-identifiable :class:`Referable`
+        Constraint AASd-117: `ID_short` of non-identifiable :class:`Referable`
         not being a direct child of a :class:`Submodel_element_list` shall be specified.
 
     .. note::
 
-        Due to implementation limitations, this cannot be checked at :class:`ID_short`
-        level or at :class:`Referable` s, rather it has to be checked at the level of
-        the parent-object holding the :class:`Referable` s.
+        Due to implementation limitations, this cannot be checked at
+        :class:`ID_short_type` level or at :class:`Referable` s,
+        rather it has to be checked at the level of the parent-object
+        holding the :class:`Referable` s.
 
         An :class:`Asset_administration_shell` -object can never be a child of a
-        :class:`Submodel_element_list`, therefore check that :class:`ID_short` is set.
+        :class:`Submodel_element_list`, therefore check that `ID_short` is set.
 
         A :class:`Submodel`-object can never be a child of a
         :class:`Submodel_element_list` , as well as its children are not children of
-        :class:`Submodel_element_list` , therefore check that its own :class:`ID_short`
-        as well as its children's :class:`ID_short` is not `None`.
+        :class:`Submodel_element_list` , therefore check that its own `ID_short`
+        as well as its children's `ID_short` is not `None`.
 
         A :class:`Submodel_element_collection` can be child of a
         :class:`Submodel_element_list` , its children cannot, though. Therefore check
-        that its children have :class:`ID_short` set.
+        that its children have `ID_short` set.
 
         An :class:`Operation_variable` has a :attr:`Operation_variable.value`, that
         is not child of a :class:`Submodel_element_list` , therefore check that its
-        :class:`ID_short` is not `None`.
+        `ID_short` is not `None`.
     """
 
 

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -4010,13 +4010,9 @@ class Operation(Submodel_element):
 
 # fmt off
 @invariant(
-    lambda self:
-    all(
-        element.ID_short is not None
-        for element in self.value
-    ),
+    lambda self: all(element.ID_short is not None for element in self.value),
     "Constraint AASd-117: ID-short of of Referables not being a direct child of a"
-    "Submodel element list shall be specified"
+    "Submodel element list shall be specified",
 )
 # fmt on
 @reference_in_the_book(section=(5, 3, 7, 11), index=1)

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -1423,23 +1423,23 @@ class ID_short_type(Name_type, DBC):
     .. note::
 
         Due to implementation limitations, this cannot be checked at :class:`ID_short`
-        level or at :class:`Referable`s, rather it has to be checked at the level of
-        the parent-object holding the :class:`Referable`s.
+        level or at :class:`Referable` s, rather it has to be checked at the level of
+        the parent-object holding the :class:`Referable` s.
 
-        An :class:`Asset_administration_shell`-object can never be a child of a
+        An :class:`Asset_administration_shell` -object can never be a child of a
         :class:`Submodel_element_list`, therefore check that :class:`ID_short` is set.
 
         A :class:`Submodel`-object can never be a child of a
-        :class:`Submodel_element_list`, as well as its children are not children of
-        :class:`Submodel_element_list`, therefore check that its own :class:`ID_short`
+        :class:`Submodel_element_list` , as well as its children are not children of
+        :class:`Submodel_element_list` , therefore check that its own :class:`ID_short`
         as well as its children's :class:`ID_short` is not `None`.
 
         A :class:`Submodel_element_collection` can be child of a
-        :class:`Submodel_element_list`, its children cannot, though. Therefore check
+        :class:`Submodel_element_list` , its children cannot, though. Therefore check
         that its children have :class:`ID_short` set.
 
         An :class:`Operation_variable` has a :attr:`Operation_variable.value`, that
-        is not child of a :class:`Submodel_element_list`, therefore check that its
+        is not child of a :class:`Submodel_element_list` , therefore check that its
         :class:`ID_short` is not `None`.
     """
 

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -1433,7 +1433,7 @@ class ID_short_type(Name_type, DBC):
         A :class:`Submodel`-object can never be a child of a
         :class:`Submodel_element_list` , as well as its children are not children of
         :class:`Submodel_element_list` , therefore check that its own ID-short
-        as well as its children's ID-short is not `None`.
+        as well as its children's ID-short is not None.
 
         A :class:`Submodel_element_collection` can be child of a
         :class:`Submodel_element_list` , its children cannot, though. Therefore check
@@ -1441,7 +1441,7 @@ class ID_short_type(Name_type, DBC):
 
         An :class:`Operation_variable` has a :attr:`Operation_variable.value`, that
         is not child of a :class:`Submodel_element_list` , therefore check that its
-        ID-short is not `None`.
+        ID-short is not None.
     """
 
 


### PR DESCRIPTION
This implements the missing invariant for AASd-117 namely, that any `Referable` that is not direct child of a `Submodel_element_list` must have its `ID_short` set. This fixes #253.

Since it is impossible to access an object's parent, we need to implement it in a creative way. 
Therefore, we add the invariant to every `Referable` object that it can apply to:

- `Asset_administration_shell`: An AAS-object can never be a child of a `Submodel_element_list`

- `Submodel`: Similarly, a `Submodel`-object is never a child of a `Submodel_element_list`. 
  Additionaly, every child of a `Submodel` is evidentally not a child of a `Submodel_element_list`.

- `Submodel_element_collection`: Every child of a SEC is never a child of a `Submodel_element_list`. 
  Careful, though, a `Submodel_element_collection` may be a child of a 
  `Submodel_element_list` though. Therefore, we cannot check for its own `ID_short` to be set.

- `Operation_variable`: has a `value`, that is not child of a `Submodel_element_list`, 
  therefore check that its `ID_short` is not `None`

Note that the logic already existed for most objects, but there was no reference to the constraint