### PR TITLE
[v3.0] Fix order of Enumeration `Fragment_keys` 

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -4897,7 +4897,6 @@ Enumeration of all referable elements within an asset administration shell""",
 
 Fragment_keys: Set[Key_types] = constant_set(
     values=[
-        Key_types.Fragment_reference,
         Key_types.Annotated_relationship_element,
         Key_types.Basic_event_element,
         Key_types.Blob,
@@ -4906,6 +4905,7 @@ Fragment_keys: Set[Key_types] = constant_set(
         Key_types.Entity,
         Key_types.Event_element,
         Key_types.File,
+        Key_types.Fragment_reference,
         Key_types.Multi_language_property,
         Key_types.Operation,
         Key_types.Property,


### PR DESCRIPTION
Fixes #244

The order of `Fragment_keys` was changed in the spec to be alphabetically. This adapts aas-core-meta to this change.