### PR TITLE
[V3] Make ID-shorts optional in `Identifiable`

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -1712,22 +1712,6 @@ class Identifiable(Referable):
     ID: "Identifier"
     """The globally unique identification of the element."""
 
-    ID_short: "ID_short_type"
-    """
-    In case of identifiables this attribute is a short name of the element.
-    In case of referable this ID is an identifying string of the element within
-    its name space.
-
-    .. note::
-
-        In case the element is a property and the property has a semantic definition
-        (:attr:`Has_semantics.semantic_ID`) conformant to IEC61360
-        the :attr:`ID_short` is typically identical to the short name in English.
-
-    :attr:`ID_short` is strengthened to required in this class,
-    see :constraintref:`AASd-117`.
-    """
-
     def __init__(
         self,
         ID_short: ID_short_type,

--- a/tests/test_v3.py
+++ b/tests/test_v3.py
@@ -1463,6 +1463,10 @@ Observed literals: {sorted(literal_set)!r}"""
             aas_core_codegen.common.Identifier("Referable")
         )
 
+        identifiable_cls = symbol_table.must_find_class(
+            aas_core_codegen.common.Identifier("Identifiable")
+        )
+
         submodel_element_cls = symbol_table.must_find_class(
             aas_core_codegen.common.Identifier("Submodel_element")
         )
@@ -1486,6 +1490,12 @@ Observed literals: {sorted(literal_set)!r}"""
             # ``Submodel_element`` inherits from it, and the submodel elements can be
             # in the value of ``Submodel_element_list``.
             if id(submodel_element_cls) in our_type.descendant_id_set:
+                continue
+
+            # NOTE (mristin, 2023-03-22):
+            # Identifiables are not affected by Constraint-117 so their ID-shorts remain
+            # optional.
+            if our_type.is_subclass_of(identifiable_cls):
                 continue
 
             # NOTE (mristin, 2023-03-17):


### PR DESCRIPTION
We misinterpreted Constraint AASd-117, and made ID-shorts required in identifiables.

This patch fixes the issue by making ID-shorts optional in `Identifiable` class again.