### PR TITLE
Detect issues in code with pylint

### DIFF
--- a/htmlgen/description.py
+++ b/htmlgen/description.py
@@ -1006,8 +1006,6 @@ def _render_description_of_signature(
             assert remark_node is not None
             remark_nodes.append(remark_node)
 
-    # TODO (mristin, 2023-01-13): render param nodes with "{signature name}-{name}" anchor and <dl>
-    # TODO (mristin, 2023-01-13): define Return with "{signature}-return" anchor as <dt><dd>
     args_and_return_nodes = []  # type: List[_NodeUnion]
 
     for name, docutils_element in description.arguments_by_name.items():

--- a/htmlgen/for_metamodel.py
+++ b/htmlgen/for_metamodel.py
@@ -233,8 +233,8 @@ def _generate_nav(
     lis.append('<li class="nav-item mt-2">Constants</li>')
 
     constants = sorted(
-        [constant for constant in symbol_table.constants],
-        key=lambda constant: constant.name,
+        list(symbol_table.constants),
+        key=lambda a_constant: a_constant.name,
     )
     for constant in constants:
         a_class = "nav-item active" if active_item is constant else "nav-item"
@@ -278,11 +278,8 @@ def _generate_nav(
     lis.append('<li class="nav-item mt-2">Verification Functions</li>')
 
     verification_functions = sorted(
-        [
-            verification_function
-            for verification_function in symbol_table.verification_functions
-        ],
-        key=lambda verification_function: verification_function.name,
+        list(symbol_table.verification_functions),
+        key=lambda a_verification_function: a_verification_function.name,
     )
     for verification_function in verification_functions:
         a_class = (
@@ -864,7 +861,6 @@ def _property_as_dt_dd(
 {dd_element}"""
     ), None
 
-# TODO (mristin, 2023-01-18): include htmlgen in precommit for black and mypy
 
 def  _render_type_annotation_recursively(
         type_annotation: intermediate.TypeAnnotationUnion
@@ -1446,25 +1442,6 @@ DEDENT!]]"""
     )
 
 
-# TODO (mristin, 2023-01-13): continue here, implement constrained primitive
-# TODO (mristin, 2023-01-13): list constraints, show invariants, show inherited invariants
-# TODO (mristin, 2023-01-13): show invariants simply as dt for text and dd with pre
-
-
-# TODO (mristin, 2023-01-13): put types in header of a verification function
-# TODO (mristin, 2023-01-13): include the source code with <pre>
-
-# TODO (mristin, 2023-01-13): hide properties with https://getbootstrap.com/docs/5.0/components/accordion/
-# TODO (mristin, 2023-01-13): properties, methods, literals etc. have simple anchor, "#{name}"
-
-# TODO (mristin, 2023-01-13): for a concrete or abstract class: hide inherited invariants with accordion
-# TODO (mristin, 2023-01-13): show invariants as code + text
-
-# TODO (mristin, 2023-01-13): for property: prefix cardinality if optional (0..1) or list (1..*)
-# TODO (mristin, 2023-01-13): for property: link to our type
-
-# TODO (mristin, 2023-01-13): use pygments to colorize the source code
-
 # fmt: off
 @ensure(
     lambda result:
@@ -1609,16 +1586,15 @@ def generate(
                 atok=atok,
             )
         else:
-            # TODO (mristin, 2023-01-13): assert_never when done
-            pass
+            assert_never(something)
 
         if error is not None:
             errors.append(error)
         else:
-            # TODO (mristin, 2023-01-13): remove this is not None once done
-            if page is not None:
-                (target_dir / f"{something.name}.html").write_text(
-                    page, encoding="utf-8"
-                )
+            assert page is not None
+
+            (target_dir / f"{something.name}.html").write_text(
+                page, encoding="utf-8"
+            )
 
     return errors

--- a/htmlgen/main.py
+++ b/htmlgen/main.py
@@ -12,7 +12,6 @@ import aas_core_codegen.run
 import asttokens
 import pygments.formatters
 from aas_core_codegen import intermediate
-from aas_core_codegen.common import Error
 from icontract import require, ensure
 
 import htmlgen.for_metamodel
@@ -57,7 +56,7 @@ def _load_meta_model(
     if error is not None:
         writer = io.StringIO()
         aas_core_codegen.run.write_error_report(
-            message=f"Failed to construct the symbol table",
+            message="Failed to construct the symbol table",
             errors=[lineno_columner.error_message(error)],
             stderr=writer,
         )
@@ -72,8 +71,8 @@ def _load_meta_model(
     if error is not None:
         writer = io.StringIO()
         aas_core_codegen.run.write_error_report(
-            message=f"Failed to translate the parsed symbol table "
-            f"to intermediate symbol table",
+            message="Failed to translate the parsed symbol table "
+            "to intermediate symbol table",
             errors=[lineno_columner.error_message(error)],
             stderr=writer,
         )

--- a/precommit.py
+++ b/precommit.py
@@ -18,6 +18,7 @@ class Step(enum.Enum):
     AAS_CORE_CODEGEN_SMOKE = "aas-core-codegen-smoke"
     TEST = "test"
     CHECK_INIT_AND_SETUP_COINCIDE = "check-init-and-setup-coincide"
+    PYLINT = "pylint"
 
 
 def call_and_report(
@@ -267,6 +268,21 @@ def main() -> int:
             return 1
     else:
         print("Skipped checking that aas_core_meta/__init__.py and setup.py coincide.")
+
+    if Step.PYLINT in selects and Step.PYLINT not in skips:
+        print("Pylint'ing...")
+        pylint_targets = ["tests", "htmlgen"]
+        rcfile = "pylint.rc"
+
+        exit_code = call_and_report(
+            verb="pylint",
+            cmd=[sys.executable, "-m", "pylint", f"--rcfile={rcfile}"] + pylint_targets,
+            cwd=repo_root,
+        )
+        if exit_code != 0:
+            return 1
+    else:
+        print("Skipped pylint'ing.")
 
     return 0
 

--- a/pylint.rc
+++ b/pylint.rc
@@ -1,0 +1,11 @@
+[TYPECHECK]
+ignored-modules = numpy
+ignored-classes = numpy,PurePath
+generated-members=bottle\.request\.forms\.decode,bottle\.request\.query\.decode
+
+[FORMAT]
+max-line-length=120
+
+[MESSAGES CONTROL]
+disable=too-few-public-methods,len-as-condition,duplicate-code,no-else-raise,no-else-return,too-many-locals,too-many-branches,too-many-nested-blocks,too-many-return-statements,unsubscriptable-object,not-an-iterable,broad-except,too-many-statements,protected-access,unnecessary-pass,too-many-statements,too-many-arguments,no-member,too-many-instance-attributes,too-many-lines,undefined-variable,unnecessary-lambda,assignment-from-none,useless-return,unused-argument,too-many-boolean-expressions,consider-using-f-string,use-dict-literal,invalid-name,no-else-continue,no-else-break,unneeded-not,too-many-public-methods
+

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         "dev": [
             "black==22.3.0",
             "mypy==0.910",
+            "pylint==2.17.0",
             "asttokens>=2.0.8,<3",
             "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@168c84e#egg=aas-core-codegen",
             "astpretty==3.0.0",

--- a/tests/common.py
+++ b/tests/common.py
@@ -13,6 +13,8 @@ from aas_core_codegen import intermediate, infer_for_schema
 
 
 class MetaModel:
+    """Bundle all the information about a parsed and understood meta-model."""
+
     #: Tokens of the original meta-model
     atok: Final[asttokens.ASTTokens]
 

--- a/tests/test_v3.py
+++ b/tests/test_v3.py
@@ -1,3 +1,5 @@
+"""Test the functions and assertions of v3.py meta-model."""
+
 import pathlib
 import unittest
 from typing import List, Set, Optional, Tuple
@@ -7,8 +9,10 @@ from aas_core_codegen import intermediate
 from aas_core_codegen.common import Identifier
 from aas_core_codegen.infer_for_schema import match as infer_for_schema_match
 
-import aas_core_meta.v3 as v3
+from aas_core_meta import v3
 import tests.common
+
+# pylint: disable=missing-docstring
 
 
 class Test_matches_XML_serializable_string(unittest.TestCase):
@@ -1206,6 +1210,7 @@ class Test_assertions(unittest.TestCase):
         }
 
         if class_name_set != literal_set:
+            # pylint: disable=line-too-long
             errors.append(
                 f"""\
 The sub-classes of {referable_cls.name} which are not {identifiable_cls.name} do not correspond to {aas_referable_non_identifiables_set.name}.
@@ -1259,7 +1264,7 @@ Observed literals: {sorted(literal_set)!r}"""
     def test_constraint_119_in_all_qualifiable_with_has_kind(self) -> None:
         renegade_classes = []  # type: List[str]
 
-        expected_condition_str = f"""\
+        expected_condition_str = """\
 (
     not (self.qualifiers is not None)
     or (
@@ -1452,11 +1457,6 @@ Observed literals: {sorted(literal_set)!r}"""
             )
 
     def test_constraint_117_on_non_submodel_element(self) -> None:
-        expected_description = (
-            "Constraint AASd-117: ID-short of Referables not being "
-            "a direct child of a Submodel element list shall be specified."
-        )
-
         symbol_table = _META_MODEL.symbol_table
 
         referable_cls = symbol_table.must_find_class(

--- a/tests/test_v3rc2.py
+++ b/tests/test_v3rc2.py
@@ -1,3 +1,5 @@
+# pylint: disable=missing-docstring
+
 import pathlib
 import unittest
 from typing import List, Set, Optional
@@ -1233,6 +1235,7 @@ class Test_assertions(unittest.TestCase):
         }
 
         if class_name_set != literal_set:
+            # pylint: disable=line-too-long
             errors.append(
                 f"""\
 The sub-classes of {referable_cls.name} which are not {identifiable_cls.name} do not correspond to {aas_referable_non_identifiables_set.name}.
@@ -1240,6 +1243,7 @@ The sub-classes of {referable_cls.name} which are not {identifiable_cls.name} do
 Observed classes:  {sorted(class_name_set)!r}
 Observed literals: {sorted(literal_set)!r}"""
             )
+            # pylint: enable=line-too-long
 
         if len(errors) != 0:
             raise AssertionError("\n".join(f"* {error}" for error in errors))
@@ -1286,7 +1290,7 @@ Observed literals: {sorted(literal_set)!r}"""
     def test_constraint_119_in_all_qualifiable_with_has_kind(self) -> None:
         renegade_classes = []  # type: List[str]
 
-        expected_condition_str = f"""\
+        expected_condition_str = """\
 not (self.qualifiers is not None)
     or (
         not any(


### PR DESCRIPTION
We run pylint on htmlgen and tests to detect issues in code. We skip the meta-models intentionally, as they do not conform to "normal" code expected by pylint.