### PR TITLE
List all descendants of a cls in html-doc

### DIFF
--- a/htmlgen/for_metamodel.py
+++ b/htmlgen/for_metamodel.py
@@ -1058,13 +1058,13 @@ def _generate_page_for_class(
             )
         )
 
-    if len(cls.concrete_descendants) > 0:
+    if len(cls.descendants) > 0:
         li_descendants = [
             f"""\
 <li>
 {I}<a href="{descendant.name}.html">{descendant.name}</a>
 </li>"""
-            for descendant in cls.concrete_descendants
+            for descendant in cls.descendants
         ]
 
         li_descendants_joined = "\n".join(li_descendants)
@@ -1080,7 +1080,7 @@ def _generate_page_for_class(
                 f"""\
 <h2>
 {I}<a name="concrete-descendants"></a>
-{I}Concrete Descendants
+{I}Descendants
 {I}<a class="aas-anchor-link" href="#concrete-descendants">🔗</a>
 </h2>
 {ul_descendants}"""

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
             "mypy==0.910",
             "pylint==2.17.0",
             "asttokens>=2.0.8,<3",
-            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@b2c0e4a#egg=aas-core-codegen",
+            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@67f789e#egg=aas-core-codegen",
             "astpretty==3.0.0",
             "pygments>=2,<3"
         ],

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
             "mypy==0.910",
             "pylint==2.17.0",
             "asttokens>=2.0.8,<3",
-            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@168c84e#egg=aas-core-codegen",
+            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@b2c0e4a#egg=aas-core-codegen",
             "astpretty==3.0.0",
             "pygments>=2,<3"
         ],


### PR DESCRIPTION
Currently, only concrete descendants are listed in the generated HTML documentation. However, many readers want to see a full list of descendants, and not only the concrete ones.

Therefore, we introduced ``descendants`` property in [aas_core_codegen.intermediate.Class], and leverage it in this patch.

[aas_core_codegen.intermediate.Class]: https://github.com/aas-core-works/aas-core-codegen/blob/b2c0e4a8e5622d2718371a5999d4aa3be9a9af9b/aas_core_codegen/intermediate/_types.py#L1437
