### PR TITLE
[V3] Remove "in-progress" suffix from the version

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -107,7 +107,7 @@ from aas_core_meta.marker import (
 )
 
 __book_url__ = "https://to-be-published"
-__book_version__ = "V3.0-work-in-progress"
+__book_version__ = "V3.0"
 
 __xml_namespace__ = "https://admin-shell.io/aas/3/0"
 


### PR DESCRIPTION
As the schemas have been officially published, we remove the "in-progress" suffix from the version identifier.