### PR TITLE
Fix nullability check in AASd-129

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -2440,7 +2440,7 @@ class Specific_asset_ID(Has_semantics):
     lambda self:
     not (self.submodel_elements is not None)
     or (
-        not (self.kind != Modelling_kind.Template)
+        not (self.kind_or_default() != Modelling_kind.Template)
         or (
             all(
                 not (submodel_element.qualifiers is not None)


### PR DESCRIPTION
We forgot to use `kind_or_default`, which is a non-nullable, and used a `kind`, which can be `None`. The patch fixes this issue.