### PR TITLE
Add `non_mutating` marker

### DIFF
--- a/aas_core_meta/marker.py
+++ b/aas_core_meta/marker.py
@@ -38,6 +38,21 @@ def implementation_specific(thing: Any) -> Any:
     return thing
 
 
+def non_mutating(thing: CallableT) -> CallableT:
+    """
+    Mark the method as non-mutating.
+
+    At the moment (2023-07-07), the non-mutating property of the method will *not*
+    be checked by the downstream code generators as that is very complex. Some compilers
+    might partially enforce it (such as popular C++ compilers like clang or g++), but
+    bear in mind that they also do not completely cover the whole problem space.
+
+    See, for example, this paper for some background:
+    https://pm.inf.ethz.ch/publications/LeinoMuellerWallenburg08.pdf
+    """
+    return thing
+
+
 def comment(text: str) -> None:
     """Mark a comment to be included in the generated code."""
     pass

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -103,6 +103,7 @@ from aas_core_meta.marker import (
     implementation_specific,
     verification,
     constant_set,
+    non_mutating,
 )
 
 __version__ = "V3.0"
@@ -1532,6 +1533,7 @@ class Extension(Has_semantics):
     """
 
     @implementation_specific
+    @non_mutating
     def value_type_or_default(self) -> "Data_type_def_XSD":
         # NOTE (mristin, 2022-04-7):
         # This implementation will not be transpiled, but is given here as reference.
@@ -1781,6 +1783,7 @@ class Has_kind(DBC):
     """
 
     @implementation_specific
+    @non_mutating
     def kind_or_default(self) -> "Modelling_kind":
         # NOTE (mristin, 2022-04-7):
         # This implementation will not be transpiled, but is given here as reference.
@@ -2007,6 +2010,7 @@ class Qualifier(Has_semantics):
     """
 
     @implementation_specific
+    @non_mutating
     def kind_or_default(self) -> "Qualifier_kind":
         # NOTE (mristin, 2022-05-24):
         # This implementation will not be transpiled, but is given here as reference.
@@ -2759,6 +2763,7 @@ class Submodel_element_list(Submodel_element):
     """
 
     @implementation_specific
+    @non_mutating
     def order_relevant_or_default(self) -> bool:
         # NOTE (mristin, 2022-04-7):
         # This implementation will not be transpiled, but is given here as reference.
@@ -2961,6 +2966,7 @@ class Data_element(Submodel_element):
         )
 
     @implementation_specific
+    @non_mutating
     @ensure(lambda result: result in Valid_categories_for_data_element)
     def category_or_default(self) -> str:
         # NOTE (mristin, 2022-04-7):

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
             "mypy==0.910",
             "pylint==2.17.0",
             "asttokens>=2.0.8,<3",
-            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@f5374a5#egg=aas-core-codegen",
+            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@6917e6f#egg=aas-core-codegen",
             "astpretty==3.0.0",
             "pygments>=2,<3"
         ],


### PR DESCRIPTION
We introduce the marker `non_mutating` to mark instance methods as non-mutating, *i.e.*, "const" in C++ jargon.

This is necessary so that we can generate later tighter code in C++ and related languages with "const" qualifiers for the member functions.