### PR TITLE
[V3] Fix AASc-3a-010-for-NAND

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -5541,13 +5541,9 @@ def is_BCP_47_for_english(text: str) -> bool:
 )
 @invariant(
     lambda self:
-    (
-            self.value is not None
-            and self.value_list is None
-    ) or (
-            self.value is None
-            and self.value_list is not None
-            and len(self.value_list.value_reference_pairs) >= 1
+    not (
+        self.value is not None
+        and self.value_list is not None
     ),
     "Constraint AASc-3a-010: If value is not empty then value list shall be empty and "
     "vice versa."


### PR DESCRIPTION
We misinterpreted the text of the constraint AASc-3a-010. It does *not* mean an exclusive OR, but rather a NAND. Both `value` and `value_list` *should not* be specified.

This patch adjusts the code to fit the text, to the best of our understanding.

We also remove the redundant part of the constraint related to the length of `value_reference_pairs` of `value_list` as that is already verified in the class `Value_list`.

Fixes #279.