### PR TITLE
[V3] Fix invariant descriptions with escapes

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -1238,7 +1238,7 @@ class Non_empty_XML_serializable_string(str, DBC):
     :constraint AASd-130:
 
         An attribute with data type "string" shall consist of these characters only:
-        ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u00010000-\u0010FFFF]*$.
+        ``^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u00010000-\u0010FFFF]*$``.
     """
 
 


### PR DESCRIPTION
We have to represent escapes in invariant descriptions as literals since Sphinx interpretes them as escaped characters otherwise. See [Sphinx docs] and [this StackOverflow question].

[Sphinx docs]: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#escaping-mechanism
[this StackOverflow question]: https://stackoverflow.com/questions/57265111/escape-special-characters-in-restructuredtext-sphinx