### PR TITLE
Fix htmlgen for pattern verifications

### DIFF
--- a/htmlgen/main.py
+++ b/htmlgen/main.py
@@ -7,6 +7,7 @@ import pathlib
 import sys
 from typing import Tuple, Optional, List
 
+import aas_core_codegen.common
 import aas_core_codegen.parse
 import aas_core_codegen.run
 import asttokens
@@ -208,9 +209,19 @@ def main() -> int:
 
         target_dir = html_dir / model_path.stem
         target_dir.mkdir(exist_ok=True)
-        htmlgen.for_metamodel.generate(
+        errors = htmlgen.for_metamodel.generate(
             symbol_table=symbol_table, atok=atok, target_dir=target_dir
         )
+
+        if len(errors) > 0:
+            lineno_columner = aas_core_codegen.common.LinenoColumner(atok=atok)
+
+            aas_core_codegen.run.write_error_report(
+                message=f"Failed to generate the documentation for {model_path}",
+                errors=[lineno_columner.error_message(error) for error in errors],
+                stderr=sys.stderr,
+            )
+            return 1
 
         names_paths.append(
             (

--- a/htmlgen/transpilation.py
+++ b/htmlgen/transpilation.py
@@ -472,12 +472,22 @@ class _Transpiler(
                     Stripped(f"<span class='nb'>len</span>{LPAREN}{args[0]}{RPAREN}"),
                     None,
                 )
+            elif func_type.func.name == "match":
+                joined_args = ",\n".join(args)
 
+                return (
+                    Stripped(
+                        f"<span class='nb'>match</span>{LPAREN}\n"
+                        f"{I}{indent_but_first_line(joined_args, I)}\n"
+                        f"{RPAREN}"
+                    ),
+                    None,
+                )
             else:
                 return None, Error(
                     node.original_node,
-                    f"The handling of the built-in function {node.name!r} has not "
-                    f"been implemented",
+                    f"The handling of the built-in function {node.name.identifier!r} "
+                    f"has not been implemented",
                 )
         else:
             assert_never(func_type)


### PR DESCRIPTION
We transpile pattern verification functions to HTML code. This is something we haven't done in codegen, and a bug eventually slipped in where the errors were unexpectedly silenced. Notable, the `re.match` function has not been set properly in the transpilation environment.

In this patch, we fix both the error reporting in the main program as well as the transpilation of pattern verifications.

Fixes #292.