### PR TITLE
Add missing docstring for AASd-120

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -2738,6 +2738,11 @@ class Submodel_element_list(Submodel_element):
         specify a :attr:`Has_semantics.semantic_ID` then the value is assumed to be
         identical to :attr:`Submodel_element_list.semantic_ID_list_element`.
 
+    :constraint AASd-120:
+
+        The :attr:`ID_short` of a :class:`Submodel_element` being a direct child of a
+        :class:`Submodel_element_list` shall not be specified.
+
     :constraint AASd-108:
 
         All first level child elements in a :class:`Submodel_element_list` shall have


### PR DESCRIPTION
Previously, AASd-120 was already implemented as invariant, 
however it was not mentioned in the docstring of class 
`Submodel_element_list`.

This PR adds the missing mention in the docstring.

Fixes #294