### PR TITLE
V3.1: Add Role value to Asset_kind enumeration

### DIFF
--- a/aas_core_meta/v3_1.py
+++ b/aas_core_meta/v3_1.py
@@ -2338,6 +2338,11 @@ class Asset_kind(Enum):
     Instance asset
     """
 
+    Role = "Role"
+    """
+    Role asset
+    """
+
     Not_applicable = "NotApplicable"
     """
     Neither a type asset nor an instance asset


### PR DESCRIPTION
A new enumeration value has been added to class `Asset_kind`, see 
[aas-specs#294](https://github.com/admin-shell-io/aas-specs/issues/294)

Note, that I didn't modify the unittests, as it would appear, there's 
no specific test for enum values. 

Fixes #302