### PR TITLE
V3.1: Relax matches_id_short regex.

### DIFF
--- a/aas_core_meta/v3_1.py
+++ b/aas_core_meta/v3_1.py
@@ -119,7 +119,7 @@ def matches_ID_short(text: str) -> bool:
     """
     Check that :paramref:`text` is a valid short ID.
     """
-    pattern = f"^[a-zA-Z][a-zA-Z0-9_]*$"
+    pattern = f"^[a-zA-Z][a-zA-Z0-9_-]*[a-zA-Z0-9_]+$"
 
     return match(pattern, text) is not None
 
@@ -1415,8 +1415,8 @@ class Value_data_type(str, DBC):
 
 @invariant(
     lambda self: matches_ID_short(self),
-    "ID-short of Referables shall only feature letters, digits, underscore (``_``); "
-    "starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]*``.",
+    "ID-short of Referables shall only feature letters, digits, hyphen (``-``) and  underscore (``_``); "
+    "starting mandatory with a letter, and not ending with a hyphen, *I.e.* ``^[a-zA-Z][a-zA-Z0-9_-]*[a-zA-Z0-9_]+$``.",
 )
 class ID_short_type(Name_type, DBC):
     """


### PR DESCRIPTION
Previously, the `matches_id_short` regular expression only allowed letters, digits and underscores.

With the decision of
[aas-specs#295](https://github.com/admin-shell-io/aas-specs/issues/295), 
this condition was relaxed to allow also hyphens.

Fixes #304