### PR TITLE
Adapt Asset_kind docstring to be more precise

### DIFF
--- a/aas_core_meta/v3_1.py
+++ b/aas_core_meta/v3_1.py
@@ -2345,7 +2345,7 @@ class Asset_kind(Enum):
 
     Not_applicable = "NotApplicable"
     """
-    Neither a type asset nor an instance asset
+    Neither a type asset nor an instance asset nor a role asset
     """
 
 


### PR DESCRIPTION
Previously, the docstring of `Asset_kind.Not_applicable` did not 
reflect the newly added `Asset_kind.Role` attribute. 
With this change, we make it more precise. 