### PR TITLE
Adapt docstring of ID_short_type

### DIFF
--- a/aas_core_meta/v3_1.py
+++ b/aas_core_meta/v3_1.py
@@ -1425,8 +1425,8 @@ class ID_short_type(Name_type, DBC):
     :constraint AASd-002:
 
         ID-short of :class:`Referable`'s shall only feature letters, digits,
-        underscore (``_``); starting mandatory with a letter.
-        *I.e.* ``[a-zA-Z][a-zA-Z0-9_]*``.
+        hyphen (``-``) and underscore (``_``); starting mandatory with a letter,
+        and not ending with a hyphen, *I.e.* ``^[a-zA-Z][a-zA-Z0-9_-]*[a-zA-Z0-9_]+$``.
 
     :constraint AASd-117:
 


### PR DESCRIPTION
With v3.1 of the specification, the regex of `matches_id_short_type()` 
changed.
While this change has already been adapted, we forgot to adapt the 
docstring of class `ID_short_type`. 

This fixes this oversight. 
