### PR TITLE
Adapt docstring of Has_kind

### DIFF
--- a/aas_core_meta/v3_1.py
+++ b/aas_core_meta/v3_1.py
@@ -1777,7 +1777,7 @@ class Has_kind(DBC):
 
     kind: Optional["Modelling_kind"]
     """
-    Kind of the element: either type or instance.
+    Kind of the element: either template or instance.
 
     Default: :attr:`Modelling_kind.Instance`
     """


### PR DESCRIPTION
With v3.1 of the specification, the docstring of `Has_kind.kind` 
was changed.
This reflects this change. 
