### PR TITLE
V3.1: Temporarily remove PathType invariant

### DIFF
--- a/aas_core_meta/v3_1.py
+++ b/aas_core_meta/v3_1.py
@@ -1384,18 +1384,9 @@ class Content_type(Non_empty_XML_serializable_string, DBC):
     """
 
 
-@invariant(
-    lambda self: matches_RFC_8089_path(self),
-    "The value must represent a valid file URI scheme according to RFC 8089.",
-)
 class Path_type(Identifier, DBC):
     """
     Identifier
-
-    .. note::
-
-        Any string conformant to RFC8089 , the “file” URI scheme (for
-        relative and absolute file paths)
     """
 
     pass


### PR DESCRIPTION
Since the PathType does not follow RFC 8089
anymore, but the `matches_xs_any_URI()`
method produces non-compliant XSD (see #317),
as a temporary fix to allow compliant XSD schema
generation, we remove the invariant completely.

This PR should not be merged and is only for
documenting this temporary fix more visibly.
The corresponding branch should be deleted,
when #317 is fixed. 