### PR TITLE
[V3] Fix the pattern in xs:date for offset

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -507,7 +507,7 @@ def matches_xs_date(text: str) -> bool:
     month_frag = f"((0[1-9])|(1[0-2]))"
     day_frag = f"((0[1-9])|([12]{digit})|(3[01]))"
     minute_frag = f"[0-5]{digit}"
-    timezone_frag = rf"(Z|(\+|-)(0{digit}|1[0-3]):{minute_frag}|14:00)"
+    timezone_frag = rf"(Z|(\+|-)((0{digit}|1[0-3]):{minute_frag}|14:00))"
     date_lexical_rep = f"{year_frag}-{month_frag}-{day_frag}{timezone_frag}?"
 
     pattern = f"^{date_lexical_rep}$"

--- a/tests/test_v3.py
+++ b/tests/test_v3.py
@@ -198,6 +198,9 @@ class Test_matches_xs_date(unittest.TestCase):
     def test_date_with_unexpected_suffix(self) -> None:
         assert not v3.matches_xs_date("2022-04-01unexpected")
 
+    def test_with_unexpected_concatenated_time_zone(self) -> None:
+        assert not v3.matches_xs_date("0705-04-1014:00")
+
 
 class Test_matches_xs_date_time(unittest.TestCase):
     def test_empty(self) -> None:


### PR DESCRIPTION
We incorrectly did not group the offset for `+14:00` or `-14:00`, so it could be directly concatenated to the year in `xs:date`'s.

This patch fixes the issue, so the incorrect dates are correctly recognized.