### PR TITLE
[V3] Fix the pattern in xs:dateTime for offset

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -532,7 +532,7 @@ def matches_xs_date_time(text: str) -> bool:
     minute_frag = f"[0-5]{digit}"
     second_frag = f"([0-5]{digit})(\\.{digit}+)?"
     end_of_day_frag = "24:00:00(\\.0+)?"
-    timezone_frag = rf"(Z|(\+|-)(0{digit}|1[0-3]):{minute_frag}|14:00)"
+    timezone_frag = rf"(Z|(\+|-)((0{digit}|1[0-3]):{minute_frag}|14:00))"
     date_time_lexical_rep = (
         f"{year_frag}-{month_frag}-{day_frag}"
         f"T"

--- a/tests/test_v3.py
+++ b/tests/test_v3.py
@@ -198,7 +198,7 @@ class Test_matches_xs_date(unittest.TestCase):
     def test_date_with_unexpected_suffix(self) -> None:
         assert not v3.matches_xs_date("2022-04-01unexpected")
 
-    def test_with_unexpected_concatenated_time_zone(self) -> None:
+    def test_with_unexpected_concatenated_offset(self) -> None:
         assert not v3.matches_xs_date("0705-04-1014:00")
 
 
@@ -235,6 +235,9 @@ class Test_matches_xs_date_time(unittest.TestCase):
 
     def test_date_time_with_unexpected_prefix(self) -> None:
         assert not v3.matches_xs_date_time("unexpected-prefix-2022-04-01T01:02:03Z")
+
+    def test_with_unexpected_concatenated_offset(self) -> None:
+        assert not v3.matches_xs_date_time("0532-09-07T18:47:5214:00")
 
 
 class Test_matches_xs_decimal(unittest.TestCase):


### PR DESCRIPTION
We incorrectly did not group the offset for `+14:00` or `-14:00`, so it could be directly concatenated as prefix in `xs:dateTime`'s.

This patch fixes the issue, so the incorrect date-times are correctly recognized.