### PR TITLE
Propatage the fix for time offset from V3 to V3.1

### DIFF
--- a/aas_core_meta/v3_1.py
+++ b/aas_core_meta/v3_1.py
@@ -509,7 +509,7 @@ def matches_xs_date(text: str) -> bool:
     month_frag = f"((0[1-9])|(1[0-2]))"
     day_frag = f"((0[1-9])|([12]{digit})|(3[01]))"
     minute_frag = f"[0-5]{digit}"
-    timezone_frag = rf"(Z|(\+|-)(0{digit}|1[0-3]):{minute_frag}|14:00)"
+    timezone_frag = rf"(Z|(\+|-)((0{digit}|1[0-3]):{minute_frag}|14:00))"
     date_lexical_rep = f"{year_frag}-{month_frag}-{day_frag}{timezone_frag}?"
 
     pattern = f"^{date_lexical_rep}$"
@@ -534,7 +534,7 @@ def matches_xs_date_time(text: str) -> bool:
     minute_frag = f"[0-5]{digit}"
     second_frag = f"([0-5]{digit})(\\.{digit}+)?"
     end_of_day_frag = "24:00:00(\\.0+)?"
-    timezone_frag = rf"(Z|(\+|-)(0{digit}|1[0-3]):{minute_frag}|14:00)"
+    timezone_frag = rf"(Z|(\+|-)((0{digit}|1[0-3]):{minute_frag}|14:00))"
     date_time_lexical_rep = (
         f"{year_frag}-{month_frag}-{day_frag}"
         f"T"


### PR DESCRIPTION
We propagate the fix in #320 from V3 to V3.1 where a time zone offset of `14:00` without a sign was mistakenly accepted by
the regular expressions.