### PR TITLE
Fix optional in `Embedded_data_specification`

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -5106,19 +5106,19 @@ class Data_specification_content:
 class Embedded_data_specification:
     """Embed the content of a data specification."""
 
-    data_specification: Reference
-    """Reference to the data specification"""
-
     data_specification_content: Data_specification_content
     """Actual content of the data specification"""
 
+    data_specification: Optional[Reference]
+    """Reference to the data specification"""
+
     def __init__(
         self,
-        data_specification: Reference,
         data_specification_content: Data_specification_content,
+        data_specification: Optional[Reference] = None,
     ) -> None:
-        self.data_specification = data_specification
         self.data_specification_content = data_specification_content
+        self.data_specification = data_specification
 
 
 class Data_type_IEC_61360(Enum):

--- a/aas_core_meta/v3_1.py
+++ b/aas_core_meta/v3_1.py
@@ -5107,19 +5107,19 @@ class Data_specification_content:
 class Embedded_data_specification:
     """Embed the content of a data specification."""
 
-    data_specification: Reference
-    """Reference to the data specification"""
-
     data_specification_content: Data_specification_content
     """Actual content of the data specification"""
 
+    data_specification: Optional[Reference]
+    """Reference to the data specification"""
+
     def __init__(
         self,
-        data_specification: Reference,
         data_specification_content: Data_specification_content,
+        data_specification: Optional[Reference] = None,
     ) -> None:
-        self.data_specification = data_specification
         self.data_specification_content = data_specification_content
+        self.data_specification = data_specification
 
 
 class Data_type_IEC_61360(Enum):


### PR DESCRIPTION
We mistakenly transcribed from the book. We made the `data_specification` attribute required, while the book prescribes an optional field.

Fixes #326.