### PR TITLE
Revert Optional in Embedded_data_specification

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -5109,13 +5109,13 @@ class Embedded_data_specification:
     data_specification_content: Data_specification_content
     """Actual content of the data specification"""
 
-    data_specification: Optional[Reference]
+    data_specification: Reference
     """Reference to the data specification"""
 
     def __init__(
         self,
         data_specification_content: Data_specification_content,
-        data_specification: Optional[Reference] = None,
+        data_specification: Reference,
     ) -> None:
         self.data_specification_content = data_specification_content
         self.data_specification = data_specification

--- a/aas_core_meta/v3_1.py
+++ b/aas_core_meta/v3_1.py
@@ -5110,13 +5110,13 @@ class Embedded_data_specification:
     data_specification_content: Data_specification_content
     """Actual content of the data specification"""
 
-    data_specification: Optional[Reference]
+    data_specification: Reference
     """Reference to the data specification"""
 
     def __init__(
         self,
         data_specification_content: Data_specification_content,
-        data_specification: Optional[Reference] = None,
+        data_specification: Reference,
     ) -> None:
         self.data_specification_content = data_specification_content
         self.data_specification = data_specification


### PR DESCRIPTION
In #328, we made the attribute `data_specification` in class 
`Embedded_data_specification` optional, 
since that is what we thought the specification said.
(See also the discussion in #326)

However, this was a bug in the specification, which is fixed 
in v3.0.1 of the specification.
We therefore revert these changes.

Fixes #326