### PR TITLE
Remove `matches_RFC_8089_path` invariant from `Path_type`

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -1386,10 +1386,6 @@ class Content_type(Non_empty_XML_serializable_string, DBC):
     """
 
 
-@invariant(
-    lambda self: matches_RFC_8089_path(self),
-    "The value must represent a valid file URI scheme according to RFC 8089.",
-)
 class Path_type(Identifier, DBC):
     """
     Identifier


### PR DESCRIPTION
Currently, the regex for Path type is non-compliant
to the specification v3.0.1, as it does not allow for 
AASX packages to be written.

As a temporary bugfix in v3.0.1, it was decided 
to remove the invariant check, as changing the 
pattern would result in a breaking change.
This is of course no final solution, 
there will be a better fix for version 3.1.

See also [admin-shell-io/aas-specs#299](https://github.com/admin-shell-io/aas-specs/issues/299)