### PR TITLE
[V3] Update to v3.0.1

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -5109,13 +5109,13 @@ class Embedded_data_specification:
     data_specification_content: Data_specification_content
     """Actual content of the data specification"""
 
-    data_specification: Optional[Reference]
+    data_specification: Reference
     """Reference to the data specification"""
 
     def __init__(
         self,
         data_specification_content: Data_specification_content,
-        data_specification: Optional[Reference] = None,
+        data_specification: Reference,
     ) -> None:
         self.data_specification_content = data_specification_content
         self.data_specification = data_specification

--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -1386,10 +1386,6 @@ class Content_type(Non_empty_XML_serializable_string, DBC):
     """
 
 
-@invariant(
-    lambda self: matches_RFC_8089_path(self),
-    "The value must represent a valid file URI scheme according to RFC 8089.",
-)
 class Path_type(Identifier, DBC):
     """
     Identifier

--- a/aas_core_meta/v3_1.py
+++ b/aas_core_meta/v3_1.py
@@ -5110,13 +5110,13 @@ class Embedded_data_specification:
     data_specification_content: Data_specification_content
     """Actual content of the data specification"""
 
-    data_specification: Optional[Reference]
+    data_specification: Reference
     """Reference to the data specification"""
 
     def __init__(
         self,
         data_specification_content: Data_specification_content,
-        data_specification: Optional[Reference] = None,
+        data_specification: Reference,
     ) -> None:
         self.data_specification_content = data_specification_content
         self.data_specification = data_specification


### PR DESCRIPTION
This PR collects all changes for v3.0.1 of the specification. 

Here's a list of the changes. For easier reviewing, you can refer to the mentioned PRs.
Please forgive the unconventional use of PRs, but I need to generate the new schema files asap. 

# Revert `Optional` in `Embedded_data_specification`
**(See #329)**

In #328, we made the attribute `data_specification` in class `Embedded_data_specification` optional, since that is what we thought the specification said. See also the discussion in #326.

However, this was a bug in the specification, which is fixed in v3.0.1 of the specification. We therefore revert these changes.

Fixes #326.

# Remove `matches_RFC_8089_path` invariant from `Path_type`
**(See #333)**

Currently, the regex for Path type is non-compliant to the specification v3.0.1, as it does not allow for  AASX packages to be written.

As a temporary bugfix in v3.0.1, it was decided to remove the invariant check, as changing the pattern would result in a breaking change. This is of course no final solution, there will be a better fix for version 3.1.

See also [admin-shell-io/aas-specs#299].

[admin-shell-io/aas-specs#299]: https://github.com/admin-shell-io/aas-specs/issues/299