### PR TITLE
[V3] Rename constraint AASc-002 to AASc-3a-002

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -5494,7 +5494,7 @@ def is_BCP_47_for_english(text: str) -> bool:
         is_BCP_47_for_english(lang_string.language)
         for lang_string in self.preferred_name
     ),
-    "Constraint AASc-002: preferred name shall be provided at least in English."
+    "Constraint AASc-3a-002: preferred name shall be provided at least in English."
 )
 @invariant(
     lambda self:


### PR DESCRIPTION
In version 3.0.2 of the specification of the AAS
Part 3a (IEC 613601 Data Specifiation),
constraint `AASc-002` is renamed to `AASc-3a-002`.

This PR reflects this change.