### PR TITLE
Update htmlgen to aas-core-codegen bd310fc2

### DIFF
--- a/htmlgen/description.py
+++ b/htmlgen/description.py
@@ -32,7 +32,6 @@ from aas_core_codegen.common import (
 )
 from aas_core_codegen.intermediate import (
     doc as intermediate_doc,
-    rendering as intermediate_rendering,
 )
 from icontract import require, ensure, DBC
 
@@ -146,7 +145,7 @@ class _NodeVisitor:
         self.visit(node.children)
 
 
-class _ElementRenderer(intermediate_rendering.DocutilsElementTransformer[_NodeUnion]):
+class _ElementRenderer(intermediate_doc.DocutilsElementTransformer[_NodeUnion]):
     """Render descriptions as HTML."""
 
     def __init__(

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
             "mypy==0.910",
             "pylint==2.17.0",
             "asttokens>=2.0.8,<3",
-            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@a863407#egg=aas-core-codegen",
+            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@bd310fc2#egg=aas-core-codegen",
             "astpretty==3.0.0",
             "pygments>=2,<3"
         ],


### PR DESCRIPTION
We update the code in `htmlgen` module to use the
`aas_core_codegen.intermediate.doc` instead of
`aas_core_codegen.intermediate.rendering` dependency. In aas-core-codegen, we merged `renderin` and `doc` modules in its revision 39980e50.

We update to the latest [aas-core-codegen bd310fc2] for maintenance.

[aas-core-codegen bd310fc2]: https://github.com/aas-core-works/aas-core-codegen/commit/bd310fc2