### PR TITLE
Rename constraint AASc-002 to AASc-3a-002 (#335)

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -5494,7 +5494,7 @@ def is_BCP_47_for_english(text: str) -> bool:
         is_BCP_47_for_english(lang_string.language)
         for lang_string in self.preferred_name
     ),
-    "Constraint AASc-002: preferred name shall be provided at least in English."
+    "Constraint AASc-3a-002: preferred name shall be provided at least in English."
 )
 @invariant(
     lambda self:


### PR DESCRIPTION
In version 3.0.2 of the specification of the AAS Part 3a (IEC 613601 Data Specifiation), constraint `AASc-002` is renamed to `AASc-3a-002`.

This commit reflects this change.

@mristin This is #335 again, but this time pointed at `main` instead of the `DataSpec61360/v3.0.2` branch that turned out to be unnecessary, as there were no other changes in v3.0.2 of the Part 3a spec. 
Since it is purely documentative, it should not have any effect on codegen, however it would be nice to have in `main`.