### PR TITLE
[V3] Fix AASd-109 for missing ``value``

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -2655,16 +2655,19 @@ class AAS_submodel_elements(Enum):
 @invariant(
     lambda self:
     not (
-            self.value is not None
-            and (
-                    self.type_value_list_element == AAS_submodel_elements.Property
-                    or self.type_value_list_element == AAS_submodel_elements.Range
-            )
+        self.type_value_list_element is not None
+        and (
+            self.type_value_list_element == AAS_submodel_elements.Property
+            or self.type_value_list_element == AAS_submodel_elements.Range
+        )
     ) or (
         self.value_type_list_element is not None
-        and properties_or_ranges_have_value_type(
-            self.value,
-            self.value_type_list_element
+        and (
+            (self.value is None)
+            or properties_or_ranges_have_value_type(
+                self.value,
+                self.value_type_list_element
+            )
         )
     ),
     "Constraint AASd-109: If type value list element is equal to "


### PR DESCRIPTION
Previously, we formalized Constraint AASd-109 such that it was not enforced as soon as the attribute ``value`` was not set. However, on a closer reading, it turns out that Constraint AASd-109 should be enforced even when no ``value`` is present.

Related to [aas-core3.0-csharp issue #38].

[aas-core3.0-csharp issue #38]: https://github.com/aas-core-works/aas-core3.0-csharp/issues/38