### PR TITLE
[V3] Fix AASd-109 for type inference

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -2655,11 +2655,8 @@ class AAS_submodel_elements(Enum):
 @invariant(
     lambda self:
     not (
-        self.type_value_list_element is not None
-        and (
-            self.type_value_list_element == AAS_submodel_elements.Property
-            or self.type_value_list_element == AAS_submodel_elements.Range
-        )
+        self.type_value_list_element == AAS_submodel_elements.Property
+        or self.type_value_list_element == AAS_submodel_elements.Range
     ) or (
         self.value_type_list_element is not None
         and (


### PR DESCRIPTION
We fix the invariant AASd-109 for type inference as we erroneously included a non-nullness check for a non-optional attribute (``type_value_list_element``).