### PR TITLE
V3.1: Adapt Identifier length to 2048

### DIFF
--- a/aas_core_meta/v3_1.py
+++ b/aas_core_meta/v3_1.py
@@ -1270,8 +1270,8 @@ class Blob_type(bytearray, DBC):
 
 
 @invariant(
-    lambda self: len(self) <= 2024,
-    "Identifier shall have a maximum length of 2024 characters.",
+    lambda self: len(self) <= 2048,
+    "Identifier shall have a maximum length of 2048 characters.",
 )
 class Identifier(Non_empty_XML_serializable_string, DBC):
     """

--- a/aas_core_meta/v3_1.py
+++ b/aas_core_meta/v3_1.py
@@ -1280,8 +1280,8 @@ class Identifier(Non_empty_XML_serializable_string, DBC):
 
 
 @invariant(
-    lambda self: len(self) <= 2000,
-    "Value type IEC 61360 shall have a maximum length of 2000 characters.",
+    lambda self: len(self) <= 2048,
+    "Value type IEC 61360 shall have a maximum length of 2048 characters.",
 )
 class Value_type_IEC_61360(Non_empty_XML_serializable_string):
     """


### PR DESCRIPTION
Previously, the invariant declaring the maximum length of `Identifier` was set to `2000`. We had already adapted this to `2024` according to [aas-specs#306](https://github.com/admin-shell-io/aas-specs/issues/306), however the decision was corrected to `2048` in [aas-specs#306](https://github.com/admin-shell-io/aas-specs/issues/306) and the specification adapted in [aas-specs#374](https://github.com/admin-shell-io/aas-specs/pull/374).

We therefore adapt the invariant to a maximum length of `2048`

Previously, the invariant declaring the maximum length of `Value_type_IEC_61360` was set to `2000`. Decided in [aas-specs#306](https://github.com/admin-shell-io/aas-specs/issues/306) and specified in [aas-specs-iec61360#21](https://github.com/admin-shell-io/aas-specs-iec61360/pull/21) this was adapted to `2048`.

We therefore adapt the invariant to a maximum length of `2048`


