### PR TITLE
[V3] Revert order of `Embedded_data_specification` attributes

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -5102,19 +5102,19 @@ class Data_specification_content:
 class Embedded_data_specification:
     """Embed the content of a data specification."""
 
-    data_specification_content: Data_specification_content
-    """Actual content of the data specification"""
-
     data_specification: Reference
     """Reference to the data specification"""
 
+    data_specification_content: Data_specification_content
+    """Actual content of the data specification"""
+
     def __init__(
         self,
-        data_specification_content: Data_specification_content,
         data_specification: Reference,
+        data_specification_content: Data_specification_content,
     ) -> None:
-        self.data_specification_content = data_specification_content
         self.data_specification = data_specification
+        self.data_specification_content = data_specification_content
 
 
 class Data_type_IEC_61360(Enum):


### PR DESCRIPTION
In #328, we had erroneously made `Embedded_data_specification.data_specification` optional, changing the order of the attributes of this class, as optional attributes have to be specified after mandatory ones.

In #329, we reverted the `Optional`, but kept the order of the attributes, as this didn't affect our code. However, as a result, the generated schema files that depend on the order of the attributes were suddenly not backward compatible anymore, as found in [aas-specs#477](https://github.com/admin-shell-io/aas-specs/issues/477).

This reverts the order of the attributes in class `Embedded_data_specification`.