### PR TITLE
V3.1: Remove AASd-090

### DIFF
--- a/aas_core_meta/v3_1.py
+++ b/aas_core_meta/v3_1.py
@@ -2954,26 +2954,8 @@ class Submodel_element_collection(Submodel_element):
         self.value = value
 
 
-Valid_categories_for_data_element: Set[str] = constant_set(
-    values=[
-        "CONSTANT",
-        "PARAMETER",
-        "VARIABLE",
-    ],
-    description="""\
-Categories for :class:`Data_element` as defined in :constraintref:`AASd-090`""",
-)
-
-
 # fmt: off
 @abstract
-@invariant(
-    lambda self:
-    not (self.category is not None)
-    or self.category in Valid_categories_for_data_element,
-    "Constraint AASd-090: For data elements category shall be one "
-    "of the following values: CONSTANT, PARAMETER or VARIABLE.",
-)
 # fmt: on
 class Data_element(Submodel_element):
     """
@@ -2982,13 +2964,6 @@ class Data_element(Submodel_element):
 
     A data element is a submodel element that has a value. The type of value differs
     for different subtypes of data elements.
-
-    :constraint AASd-090:
-
-        For data elements :attr:`category` shall be one of the following
-        values: ``CONSTANT``, ``PARAMETER`` or ``VARIABLE``.
-
-        Default: ``VARIABLE``
     """
 
     def __init__(
@@ -3017,14 +2992,6 @@ class Data_element(Submodel_element):
             qualifiers=qualifiers,
             embedded_data_specifications=embedded_data_specifications,
         )
-
-    @implementation_specific
-    @non_mutating
-    @ensure(lambda result: result in Valid_categories_for_data_element)
-    def category_or_default(self) -> str:
-        # NOTE (mristin, 2022-04-7):
-        # This implementation will not be transpiled, but is given here as reference.
-        return self.category if self.category is not None else "VARIABLE"
 
 
 # fmt: off


### PR DESCRIPTION
Since `Referable.category` has been deprecated in the metamodel, we remove the now unnecessary invariant `AASd-090` about
`Data_element.category`. 

See [aas-specs#514](https://github.com/admin-shell-io/aas-specs/issues/514) and [spec changelog](https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/changelog.html#_changes_v3_1_vs_v3_0_1).