### PR TITLE
V3.1: Reformulate AASd-116

### DIFF
--- a/aas_core_meta/v3_1.py
+++ b/aas_core_meta/v3_1.py
@@ -2248,9 +2248,8 @@ class Asset_information(DBC):
 
     :constraint AASd-116:
 
-        ``globalAssetId`` is a reserved key. If used as value for
-        :attr:`Specific_asset_ID.name` then :attr:`Specific_asset_ID.value` shall be
-        identical to :attr:`global_asset_ID`.
+        ``globalAssetId`` is a reserved key for :attr:`Specific_asset_ID.name` with the
+        semantics as defined in :attr:`global_asset_ID`.
 
         .. note::
 


### PR DESCRIPTION
In v3.1 of the specification, the constraint AASd-116 was reformulated.
We adapt these changes.

See [aas-specs#298](https://github.com/admin-shell-io/aas-specs/issues/298) and [aas-specs#390](https://github.com/admin-shell-io/aas-specs/issues/390).