### PR TITLE
V3.1 Update max length of Content_type

### DIFF
--- a/aas_core_meta/v3_1.py
+++ b/aas_core_meta/v3_1.py
@@ -1412,12 +1412,12 @@ class BCP_47_language_tag(str, DBC):
     "The value must represent a valid content MIME type according to RFC 2046.",
 )
 @invariant(
-    lambda self: len(self) <= 100,
-    "Content type shall have a maximum length of 100 characters.",
+    lambda self: len(self) <= 128,
+    "Content type shall have a maximum length of 128 characters.",
 )
 class Content_type(Non_empty_XML_serializable_string, DBC):
     """
-    String with length 100 maximum and minimum 1 characters
+    String with length 128 maximum and minimum 1 characters
 
     .. note::
 


### PR DESCRIPTION
Previously, class `Content_type` had a maximum length of 100 characters. This was changed to 128 in v3.1 of the specification.

See:
- Issue: [aas-specs#540](https://github.com/admin-shell-io/aas-specs/pull/540)
- PR: [aas-specs#543](https://github.com/admin-shell-io/aas-specs/pull/543)
- [Specification](https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#ContentType)