### PR TITLE
V3.1: Make `Value_reference_pair.value_id` optional

### DIFF
--- a/aas_core_meta/v3_1.py
+++ b/aas_core_meta/v3_1.py
@@ -5376,7 +5376,7 @@ class Value_reference_pair(DBC):
     The value of the referenced concept definition of the value in :attr:`value_ID`.
     """
 
-    value_ID: "Reference"
+    value_ID: Optional["Reference"]
     """
     Global unique id of the value.
 
@@ -5386,7 +5386,9 @@ class Value_reference_pair(DBC):
 
     """
 
-    def __init__(self, value: Value_type_IEC_61360, value_ID: "Reference") -> None:
+    def __init__(
+        self, value: Value_type_IEC_61360, value_ID: Optional["Reference"]
+    ) -> None:
         self.value = value
         self.value_ID = value_ID
 


### PR DESCRIPTION
Previously, `Value_reference_pair.value_id` was mandatory. In v3.1 it became optional.

See the [changelog](https://admin-shell-io.github.io/aas-specs-antora/IDTA-01003-a/v3.1/changelog.html#_changes_v3_1_vs_v3_0_2) (though it links to a wrong issue there).