### PR TITLE
v3.1: Update docstring of `ID_shorts_are_unique`

### DIFF
--- a/aas_core_meta/v3_1.py
+++ b/aas_core_meta/v3_1.py
@@ -1125,7 +1125,7 @@ def is_model_reference_to_referable(reference: "Reference") -> bool:
 def ID_shorts_are_unique(referables: List["Referable"]) -> bool:
     """
     Check that the :attr:`Referable.ID_short`'s among the :paramref:`referables` are
-    unique.
+    unique in their namespace.
     """
     # NOTE (mristin, 2022-04-7):
     # This implementation will not be transpiled, but is given here as reference.


### PR DESCRIPTION
The definition of the `ID_shorts_are_unique` invariant was updated in v3.1 of the [specification](https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/common.html#Referable).

This reflects the change.

Fixes #319