### PR TITLE
Fix inheritance of class `Value_data_type`

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -1405,7 +1405,7 @@ class Qualifier_type(Name_type, DBC):
     """
 
 
-class Value_data_type(str, DBC):
+class Value_data_type(Non_empty_XML_serializable_string, DBC):
     """
     any XSD simple type as specified via :class:`Data_type_def_XSD`
     """

--- a/aas_core_meta/v3_1.py
+++ b/aas_core_meta/v3_1.py
@@ -1451,7 +1451,7 @@ class Qualifier_type(Name_type, DBC):
     """
 
 
-class Value_data_type(str, DBC):
+class Value_data_type(Non_empty_XML_serializable_string, DBC):
     """
     any XSD simple type as specified via :class:`Data_type_def_XSD`
     """


### PR DESCRIPTION
Previously, class `Value_data_type` inherited directly from `str`, when it should have been `Non_empty_XML_serializable_string`, as with every other string-class in the specification.

Since this was a bug with aas-core and not with the specification, this adapts class inheritance for both `v3.py` and `v3_1.py`.

Fixes #331