### PR TITLE
Add missing default values to constructors with optional parameters

### DIFF
--- a/aas_core_meta/v3_1.py
+++ b/aas_core_meta/v3_1.py
@@ -3503,7 +3503,6 @@ class Entity(Submodel_element):
 
     def __init__(
         self,
-        entity_type: Optional["Entity_type"],
         extensions: Optional[List["Extension"]] = None,
         category: Optional[Name_type] = None,
         ID_short: Optional[ID_short_type] = None,
@@ -3516,6 +3515,7 @@ class Entity(Submodel_element):
             List["Embedded_data_specification"]
         ] = None,
         statements: Optional[List["Submodel_element"]] = None,
+        entity_type: Optional["Entity_type"] = None,
         global_asset_ID: Optional["Identifier"] = None,
         specific_asset_IDs: Optional[List["Specific_asset_ID"]] = None,
     ) -> None:
@@ -5387,7 +5387,9 @@ class Value_reference_pair(DBC):
     """
 
     def __init__(
-        self, value: Value_type_IEC_61360, value_ID: Optional["Reference"]
+        self,
+        value: Value_type_IEC_61360,
+        value_ID: Optional["Reference"] = None,
     ) -> None:
         self.value = value
         self.value_ID = value_ID


### PR DESCRIPTION
Previously, some class attributes were made `Optional` in v3.1 of the specification. While this change was reflected in aas-core-meta, we missed to add a default value of `None` to their parameters in the constructor methods.

Affected by this are:
- `Entity.entity_type`
- `Value_data_type.value_id`


> [!warning]
> We need to make sure that the change of the `Entity` constructor is backward compatible!
> Does it change the order of the attributes in the schema files? 
> This could mean, that actually in practice, making an attribute `Optional` in the specification is actually not necessarily backward compatible in the schema!

Edit: After checking the generated schema files, I can confirm that the change is indeed backward compatible. 