### PR TITLE
[V3.1] Fix invariant implementation of AASd-014

### DIFF
--- a/aas_core_meta/v3_1.py
+++ b/aas_core_meta/v3_1.py
@@ -3432,17 +3432,17 @@ class Annotated_relationship_element(Relationship_element):
     lambda self:
     not (self.entity_type is not None)
     or (
-        self.entity_type == Entity_type.Self_managed_entity
-        and (
-            (
-                    self.global_asset_ID is not None
-                    and self.specific_asset_IDs is None
-            ) or (
-                    self.global_asset_ID is None
-                    and self.specific_asset_IDs is not None
-                    and len(self.specific_asset_IDs) >= 1
+            not (self.entity_type == Entity_type.Self_managed_entity)
+            or (
+                    (
+                            self.global_asset_ID is not None
+                            and self.specific_asset_IDs is None
+                    ) or (
+                            self.global_asset_ID is None
+                            and self.specific_asset_IDs is not None
+                            and len(self.specific_asset_IDs) >= 1
+                    )
             )
-        )
     ),
     "Constraint AASd-014: Either the attribute global asset ID or "
     "specific asset ID must be set if Entity/entityType is set to :attr:`Entity_type.Self_managed_entity`."


### PR DESCRIPTION
Previously, v3.1 of the specification changed the formulation of AASd-014 and made `Entity.entity_type` optional, see #311.

However, we missed adapting the implementation of invariant AASd-014, which we do here now.