### PR TITLE
[V3.0 and V3.1] Fix references index constraint

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -4453,7 +4453,7 @@ class Reference_types(Enum):
     ) or (
         all(
             not (self.keys[i].type == Key_types.Submodel_element_list)
-            or matches_xs_positive_integer(self.keys[i + 1].value)
+            or matches_xs_non_negative_integer(self.keys[i + 1].value)
             for i in range(0, len(self.keys) - 1)
         )
     ),

--- a/aas_core_meta/v3_1.py
+++ b/aas_core_meta/v3_1.py
@@ -4449,7 +4449,7 @@ class Reference_types(Enum):
     ) or (
         all(
             not (self.keys[i].type == Key_types.Submodel_element_list)
-            or matches_xs_positive_integer(self.keys[i + 1].value)
+            or matches_xs_non_negative_integer(self.keys[i + 1].value)
             for i in range(0, len(self.keys) - 1)
         )
     ),

--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -4270,7 +4270,7 @@ class Reference_types(Enum):
     ) or (
         all(
             not (self.keys[i].type == Key_types.Submodel_element_list)
-            or matches_xs_positive_integer(self.keys[i + 1].value)
+            or matches_xs_non_negative_integer(self.keys[i + 1].value)
             for i in range(0, len(self.keys) - 1)
         )
     ),


### PR DESCRIPTION
AASd-128 requires that submodel element list entries in model reference paths are followed by an integer index in said list. In other places in the spec, this index is described as zero-based. Currently, the invariant for AASd-128, however, checks for the index to be a positive integer, *i.e.*, it excludes 0 from the set of valid values.

We instead constrain the index to non-negative integers to allow zero.

Fixes #369.