### PR TITLE
[V3] Add Missing Path_type Constraint

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -1398,6 +1398,10 @@ class Content_type(Non_empty_XML_serializable_string, DBC):
     """
 
 
+@invariant(
+    lambda self: matches_RFC_2396(self),
+    "String with max 2048 and min 1 characters conformant to a URI as per RFC 2396.",
+)
 class Path_type(Identifier, DBC):
     """
     Identifier


### PR DESCRIPTION
When updating from v3.0 to v3.0.1 in [#334] the RFC 8089 constraint was dropped for Path_types. As of 3.0.2 Path_types are required to be RFC 2396 conformant. With [#382] there is a suitable constraint implementation for v3. Hence, we add the missing constraint to Path_type.

[#334]: https://github.com/aas-core-works/aas-core-meta/pull/334
[#382]: https://github.com/aas-core-works/aas-core-meta/pull/382

Fixes #387.