### PR TITLE
Remove dates from the note comments

### DIFF
--- a/aas_core_meta/v3.py
+++ b/aas_core_meta/v3.py
@@ -324,7 +324,7 @@ def lang_strings_have_unique_languages(
     Check that the :paramref:`lang_strings` do not have overlapping
     :attr:`Abstract_lang_string.language`'s
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     language_set = set()
     for lang_string in lang_strings:
@@ -344,7 +344,7 @@ def qualifier_types_are_unique(qualifiers: List["Qualifier"]) -> bool:
     :param qualifiers: to be checked
     :return: True if all :attr:`Qualifier.type`'s are unique
     """
-    # NOTE (mristin, 2022-04-1):
+    # NOTE (mristin):
     # This implementation is given here only as reference. It needs to be adapted
     # for each implementation separately.
     observed_types = set()
@@ -606,7 +606,7 @@ def matches_xs_double(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See: https://www.w3.org/TR/xmlschema-2/#nt-doubleRep
     double_rep = r"((\+|-)?([0-9]+(\.[0-9]*)?|\.[0-9]+)([Ee](\+|-)?[0-9]+)?|-?INF|NaN)"
 
@@ -624,7 +624,7 @@ def matches_xs_duration(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema-2/#nt-durationRep
 
     # fmt: off
@@ -680,7 +680,7 @@ def matches_xs_g_day(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema-2/#nt-gDayRep
     g_day_lexical_rep = (
         r"---(0[1-9]|[12][0-9]|3[01])(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?"
@@ -700,7 +700,7 @@ def matches_xs_g_month(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema-2/#nt-gMonthRep
     g_month_lexical_rep = (
         r"--(0[1-9]|1[0-2])(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?"
@@ -720,7 +720,7 @@ def matches_xs_g_month_day(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema-2/#nt-gMonthDayRep
     g_month_day_rep = (
         r"--(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])"
@@ -741,7 +741,7 @@ def matches_xs_g_year(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema-2/#nt-gYearRep
     g_year_rep = (
         r"-?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?"
@@ -761,7 +761,7 @@ def matches_xs_g_year_month(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema-2/#nt-gYearMonthRep
 
     g_year_month_rep = (
@@ -783,7 +783,7 @@ def matches_xs_hex_binary(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema-2/#nt-hexBinary
     hex_binary = r"([0-9a-fA-F]{2})*"
 
@@ -801,7 +801,7 @@ def matches_xs_time(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema-2/#nt-timeRep
     time_rep = (
         r"(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?|(24:00:00(\.0+)?))"
@@ -1048,7 +1048,7 @@ def value_consistent_with_XSD_type(value: str, value_type: "Data_type_def_XSD") 
     :param value_type: pre-defined value type
     :return: True if the :paramref:`value` conforms
     """
-    # NOTE (mristin, 2022-04-1):
+    # NOTE (mristin):
     # We specify the pattern-matching functions above, and they should be handy to check
     # for most obvious pattern mismatches.
     #
@@ -1093,7 +1093,7 @@ def ID_shorts_are_unique(referables: List["Referable"]) -> bool:
     Check that the :attr:`Referable.ID_short`'s among the :paramref:`referables` are
     unique.
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     id_short_set = set()
     for referable in referables:
@@ -1118,7 +1118,7 @@ def ID_shorts_of_variables_are_unique(
     :paramref:`input_variables`, :paramref:`output_variables`
     and :paramref:`inoutput_variables` are unique.
     """
-    # NOTE (s-heppner, 2023-01-25):
+    # NOTE (s-heppner):
     # This implementation will not be transpiled, but is given here as reference.
     id_short_set = set()
     if input_variables is not None:
@@ -1149,7 +1149,7 @@ def ID_shorts_of_variables_are_unique(
 @implementation_specific
 def extension_names_are_unique(extensions: List["Extension"]) -> bool:
     """Check that the extension names are unique."""
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     name_set = set()
     for extension in extensions:
@@ -1166,7 +1166,7 @@ def submodel_elements_have_identical_semantic_IDs(
     elements: List["Submodel_element"],
 ) -> bool:
     """Check that all semantic IDs are identical, if specified."""
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as a reference.
     semantic_ID = None
     for element in elements:
@@ -1198,7 +1198,7 @@ def properties_or_ranges_have_value_type(
     elements: List["Submodel_element"], value_type: "Data_type_def_XSD"
 ) -> bool:
     """Check that all the :paramref:`elements` have the :paramref:`value_type`."""
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     for element in elements:
         if isinstance(element, (Property, Range)):
@@ -1212,7 +1212,7 @@ def properties_or_ranges_have_value_type(
 @implementation_specific
 def reference_key_values_equal(that: "Reference", other: "Reference") -> bool:
     """Check that the two references are equal by comparing their key values."""
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     if len(that.keys) != len(other.keys):
         return False
@@ -1545,7 +1545,7 @@ class Extension(Has_semantics):
     @implementation_specific
     @non_mutating
     def value_type_or_default(self) -> "Data_type_def_XSD":
-        # NOTE (mristin, 2022-04-7):
+        # NOTE (mristin):
         # This implementation will not be transpiled, but is given here as reference.
         return (
             self.value_type if self.value_type is not None else Data_type_def_XSD.String
@@ -1795,7 +1795,7 @@ class Has_kind(DBC):
     @implementation_specific
     @non_mutating
     def kind_or_default(self) -> "Modelling_kind":
-        # NOTE (mristin, 2022-04-7):
+        # NOTE (mristin):
         # This implementation will not be transpiled, but is given here as reference.
         return self.kind if self.kind is not None else Modelling_kind.Instance
 
@@ -2022,7 +2022,7 @@ class Qualifier(Has_semantics):
     @implementation_specific
     @non_mutating
     def kind_or_default(self) -> "Qualifier_kind":
-        # NOTE (mristin, 2022-05-24):
+        # NOTE (mristin):
         # This implementation will not be transpiled, but is given here as reference.
         return self.kind if self.kind is not None else Qualifier_kind.Concept_qualifier
 
@@ -2779,7 +2779,7 @@ class Submodel_element_list(Submodel_element):
     @implementation_specific
     @non_mutating
     def order_relevant_or_default(self) -> bool:
-        # NOTE (mristin, 2022-04-7):
+        # NOTE (mristin):
         # This implementation will not be transpiled, but is given here as reference.
         return self.order_relevant if self.order_relevant is not None else True
 
@@ -2983,7 +2983,7 @@ class Data_element(Submodel_element):
     @non_mutating
     @ensure(lambda result: result in Valid_categories_for_data_element)
     def category_or_default(self) -> str:
-        # NOTE (mristin, 2022-04-7):
+        # NOTE (mristin):
         # This implementation will not be transpiled, but is given here as reference.
         return self.category if self.category is not None else "VARIABLE"
 
@@ -4060,7 +4060,7 @@ class Capability(Submodel_element):
         )
 
 
-# NOTE (mristin, 2022-08-19):
+# NOTE (mristin):
 # We make the following verification functions implementation-specific since the casts
 # are very clumsy to formalize and transpile in a readable way across languages.
 # For example, since Python does not have a null-coalescing operator, formalizing
@@ -4081,7 +4081,7 @@ def data_specification_IEC_61360s_for_property_or_value_have_appropriate_data_ty
     Check that the :attr:`Data_specification_IEC_61360.data_type` is defined
     appropriately for all data specifications whose content is given as IEC 61360.
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     return all(
         not (
@@ -4110,7 +4110,7 @@ def data_specification_IEC_61360s_for_reference_have_appropriate_data_type(
     Check that the :attr:`Data_specification_IEC_61360.data_type` is defined
     appropriately for all data specifications whose content is given as IEC 61360.
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     return all(
         not (
@@ -4139,7 +4139,7 @@ def data_specification_IEC_61360s_for_document_have_appropriate_data_type(
     Check that the :attr:`Data_specification_IEC_61360.data_type` is defined
     appropriately for all data specifications whose content is given as IEC 61360.
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     return all(
         not (
@@ -4168,7 +4168,7 @@ def data_specification_IEC_61360s_have_data_type(
     Check that the :attr:`Data_specification_IEC_61360.data_type` is defined for all
     data specifications whose content is given as IEC 61360.
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     return all(
         not (
@@ -4191,7 +4191,7 @@ def data_specification_IEC_61360s_have_value(
     Check that the :attr:`Data_specification_IEC_61360.value` is defined
     for all data specifications whose content is given as IEC 61360.
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     return all(
         not (
@@ -4214,7 +4214,7 @@ def data_specification_IEC_61360s_have_definition_at_least_in_english(
     Check that the :attr:`Data_specification_IEC_61360.definition` is defined
     for all data specifications whose content is given as IEC 61360 at least in English.
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
 
     for data_specification in embedded_data_specifications:
@@ -4471,7 +4471,7 @@ class Reference_types(Enum):
     "with type Submodel element list is an integer number denoting the position in "
     "the array of the submodel element list."
 )
-# NOTE (mristin, 2022-07-10):
+# NOTE (mristin):
 # We can write AASd-127 in this simpler form assuming that AASd-126 ensures that
 # only the last key can be a fragment reference.
 @invariant(

--- a/aas_core_meta/v3_1.py
+++ b/aas_core_meta/v3_1.py
@@ -325,7 +325,7 @@ def lang_strings_have_unique_languages(
     Check that the :paramref:`lang_strings` do not have overlapping
     :attr:`Abstract_lang_string.language`'s
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     language_set = set()
     for lang_string in lang_strings:
@@ -345,7 +345,7 @@ def qualifier_types_are_unique(qualifiers: List["Qualifier"]) -> bool:
     :param qualifiers: to be checked
     :return: True if all :attr:`Qualifier.type`'s are unique
     """
-    # NOTE (mristin, 2022-04-1):
+    # NOTE (mristin):
     # This implementation is given here only as reference. It needs to be adapted
     # for each implementation separately.
     observed_types = set()
@@ -596,7 +596,7 @@ def matches_xs_double(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See: https://www.w3.org/TR/xmlschema-2/#nt-doubleRep
     double_rep = r"((\+|-)?([0-9]+(\.[0-9]*)?|\.[0-9]+)([Ee](\+|-)?[0-9]+)?|-?INF|NaN)"
 
@@ -614,7 +614,7 @@ def matches_xs_duration(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema-2/#nt-durationRep
 
     # fmt: off
@@ -670,7 +670,7 @@ def matches_xs_g_day(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema-2/#nt-gDayRep
     g_day_lexical_rep = (
         r"---(0[1-9]|[12][0-9]|3[01])(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?"
@@ -690,7 +690,7 @@ def matches_xs_g_month(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema-2/#nt-gMonthRep
     g_month_lexical_rep = (
         r"--(0[1-9]|1[0-2])(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?"
@@ -710,7 +710,7 @@ def matches_xs_g_month_day(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema-2/#nt-gMonthDayRep
     g_month_day_rep = (
         r"--(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])"
@@ -731,7 +731,7 @@ def matches_xs_g_year(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema-2/#nt-gYearRep
     g_year_rep = (
         r"-?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?"
@@ -751,7 +751,7 @@ def matches_xs_g_year_month(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema-2/#nt-gYearMonthRep
 
     g_year_month_rep = (
@@ -773,7 +773,7 @@ def matches_xs_hex_binary(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema-2/#nt-hexBinary
     hex_binary = r"([0-9a-fA-F]{2})*"
 
@@ -791,7 +791,7 @@ def matches_xs_time(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema-2/#nt-timeRep
     time_rep = (
         r"(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?|(24:00:00(\.0+)?))"
@@ -1038,7 +1038,7 @@ def value_consistent_with_XSD_type(value: str, value_type: "Data_type_def_XSD") 
     :param value_type: pre-defined value type
     :return: True if the :paramref:`value` conforms
     """
-    # NOTE (mristin, 2022-04-1):
+    # NOTE (mristin):
     # We specify the pattern-matching functions above, and they should be handy to check
     # for most obvious pattern mismatches.
     #
@@ -1083,7 +1083,7 @@ def ID_shorts_are_unique(referables: List["Referable"]) -> bool:
     Check that the :attr:`Referable.ID_short`'s among the :paramref:`referables` are
     unique in their namespace.
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     id_short_set = set()
     for referable in referables:
@@ -1108,7 +1108,7 @@ def ID_shorts_of_variables_are_unique(
     :paramref:`input_variables`, :paramref:`output_variables`
     and :paramref:`inoutput_variables` are unique.
     """
-    # NOTE (s-heppner, 2023-01-25):
+    # NOTE (s-heppner):
     # This implementation will not be transpiled, but is given here as reference.
     id_short_set = set()
     if input_variables is not None:
@@ -1139,7 +1139,7 @@ def ID_shorts_of_variables_are_unique(
 @implementation_specific
 def extension_names_are_unique(extensions: List["Extension"]) -> bool:
     """Check that the extension names are unique."""
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     name_set = set()
     for extension in extensions:
@@ -1156,7 +1156,7 @@ def submodel_elements_have_identical_semantic_IDs(
     elements: List["Submodel_element"],
 ) -> bool:
     """Check that all semantic IDs are identical, if specified."""
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as a reference.
     semantic_ID = None
     for element in elements:
@@ -1188,7 +1188,7 @@ def properties_or_ranges_have_value_type(
     elements: List["Submodel_element"], value_type: "Data_type_def_XSD"
 ) -> bool:
     """Check that all the :paramref:`elements` have the :paramref:`value_type`."""
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     for element in elements:
         if isinstance(element, (Property, Range)):
@@ -1202,7 +1202,7 @@ def properties_or_ranges_have_value_type(
 @implementation_specific
 def reference_key_values_equal(that: "Reference", other: "Reference") -> bool:
     """Check that the two references are equal by comparing their key values."""
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     if len(that.keys) != len(other.keys):
         return False
@@ -1536,7 +1536,7 @@ class Extension(Has_semantics):
     @implementation_specific
     @non_mutating
     def value_type_or_default(self) -> "Data_type_def_XSD":
-        # NOTE (mristin, 2022-04-7):
+        # NOTE (mristin):
         # This implementation will not be transpiled, but is given here as reference.
         return (
             self.value_type if self.value_type is not None else Data_type_def_XSD.String
@@ -1786,7 +1786,7 @@ class Has_kind(DBC):
     @implementation_specific
     @non_mutating
     def kind_or_default(self) -> "Modelling_kind":
-        # NOTE (mristin, 2022-04-7):
+        # NOTE (mristin):
         # This implementation will not be transpiled, but is given here as reference.
         return self.kind if self.kind is not None else Modelling_kind.Instance
 
@@ -2013,7 +2013,7 @@ class Qualifier(Has_semantics):
     @implementation_specific
     @non_mutating
     def kind_or_default(self) -> "Qualifier_kind":
-        # NOTE (mristin, 2022-05-24):
+        # NOTE (mristin):
         # This implementation will not be transpiled, but is given here as reference.
         return self.kind if self.kind is not None else Qualifier_kind.Concept_qualifier
 
@@ -2767,7 +2767,7 @@ class Submodel_element_list(Submodel_element):
     @implementation_specific
     @non_mutating
     def order_relevant_or_default(self) -> bool:
-        # NOTE (mristin, 2022-04-7):
+        # NOTE (mristin):
         # This implementation will not be transpiled, but is given here as reference.
         return self.order_relevant if self.order_relevant is not None else True
 
@@ -4010,7 +4010,7 @@ class Capability(Submodel_element):
         )
 
 
-# NOTE (mristin, 2022-08-19):
+# NOTE (mristin):
 # We make the following verification functions implementation-specific since the casts
 # are very clumsy to formalize and transpile in a readable way across languages.
 # For example, since Python does not have a null-coalescing operator, formalizing
@@ -4031,7 +4031,7 @@ def data_specification_IEC_61360s_for_property_or_value_have_appropriate_data_ty
     Check that the :attr:`Data_specification_IEC_61360.data_type` is defined
     appropriately for all data specifications whose content is given as IEC 61360.
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     return all(
         not (
@@ -4060,7 +4060,7 @@ def data_specification_IEC_61360s_for_reference_have_appropriate_data_type(
     Check that the :attr:`Data_specification_IEC_61360.data_type` is defined
     appropriately for all data specifications whose content is given as IEC 61360.
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     return all(
         not (
@@ -4089,7 +4089,7 @@ def data_specification_IEC_61360s_for_document_have_appropriate_data_type(
     Check that the :attr:`Data_specification_IEC_61360.data_type` is defined
     appropriately for all data specifications whose content is given as IEC 61360.
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     return all(
         not (
@@ -4118,7 +4118,7 @@ def data_specification_IEC_61360s_have_data_type(
     Check that the :attr:`Data_specification_IEC_61360.data_type` is defined for all
     data specifications whose content is given as IEC 61360.
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     return all(
         not (
@@ -4141,7 +4141,7 @@ def data_specification_IEC_61360s_have_value(
     Check that the :attr:`Data_specification_IEC_61360.value` is defined
     for all data specifications whose content is given as IEC 61360.
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     return all(
         not (
@@ -4164,7 +4164,7 @@ def data_specification_IEC_61360s_have_definition_at_least_in_english(
     Check that the :attr:`Data_specification_IEC_61360.definition` is defined
     for all data specifications whose content is given as IEC 61360 at least in English.
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
 
     for data_specification in embedded_data_specifications:
@@ -4421,7 +4421,7 @@ class Reference_types(Enum):
     "with type Submodel element list is an integer number denoting the position in "
     "the array of the submodel element list."
 )
-# NOTE (mristin, 2022-07-10):
+# NOTE (mristin):
 # We can write AASd-127 in this simpler form assuming that AASd-126 ensures that
 # only the last key can be a fragment reference.
 @invariant(

--- a/aas_core_meta/v3rc2.py
+++ b/aas_core_meta/v3rc2.py
@@ -278,7 +278,7 @@ def lang_strings_have_unique_languages(lang_strings: List["Lang_string"]) -> boo
     Check that the :paramref:`lang_strings` do not have overlapping
     :attr:`Lang_string.language`'s
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     language_set = set()
     for lang_string in lang_strings:
@@ -298,7 +298,7 @@ def qualifier_types_are_unique(qualifiers: List["Qualifier"]) -> bool:
     :param qualifiers: to be checked
     :return: True if all :attr:`Qualifier.type`'s are unique
     """
-    # NOTE (mristin, 2022-04-1):
+    # NOTE (mristin):
     # This implementation is given here only as reference. It needs to be adapted
     # for each implementation separately.
     observed_types = set()
@@ -555,7 +555,7 @@ def matches_xs_double(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See: https://www.w3.org/TR/xmlschema11-2/#nt-doubleRep
     double_rep = r"((\+|-)?([0-9]+(\.[0-9]*)?|\.[0-9]+)([Ee](\+|-)?[0-9]+)?|-?INF|NaN)"
 
@@ -573,7 +573,7 @@ def matches_xs_duration(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema11-2/#nt-durationRep
 
     # fmt: off
@@ -629,7 +629,7 @@ def matches_xs_g_day(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema11-2/#nt-gDayRep
     g_day_lexical_rep = (
         r"---(0[1-9]|[12][0-9]|3[01])(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?"
@@ -649,7 +649,7 @@ def matches_xs_g_month(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema11-2/#nt-gMonthRep
     g_month_lexical_rep = (
         r"--(0[1-9]|1[0-2])(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?"
@@ -669,7 +669,7 @@ def matches_xs_g_month_day(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema11-2/#nt-gMonthDayRep
     g_month_day_rep = (
         r"--(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])"
@@ -690,7 +690,7 @@ def matches_xs_g_year(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema11-2/#nt-gYearRep
     g_year_rep = (
         r"-?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?"
@@ -710,7 +710,7 @@ def matches_xs_g_year_month(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema11-2/#nt-gYearMonthRep
 
     g_year_month_rep = (
@@ -732,7 +732,7 @@ def matches_xs_hex_binary(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema11-2/#nt-hexBinary
     hex_binary = r"([0-9a-fA-F]{2})*"
 
@@ -750,7 +750,7 @@ def matches_xs_time(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema11-2/#nt-timeRep
     time_rep = (
         r"(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?|(24:00:00(\.0+)?))"
@@ -771,7 +771,7 @@ def matches_xs_day_time_duration(text: str) -> bool:
     :param text: Text to be checked
     :returns: True if the :paramref:`text` conforms to the pattern
     """
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.w3.org/TR/xmlschema11-2/#nt-durationRep and
     # https://www.w3.org/TR/xmlschema11-2/#dayTimeDuration related to pattern
     # intersection
@@ -1051,7 +1051,7 @@ def value_consistent_with_xsd_type(value: str, value_type: "Data_type_def_xsd") 
     :param value_type: pre-defined value type
     :return: True if the :paramref:`value` conforms
     """
-    # NOTE (mristin, 2022-04-1):
+    # NOTE (mristin):
     # We specify the pattern-matching functions above, and they should be handy to check
     # for most obvious pattern mismatches.
     #
@@ -1112,7 +1112,7 @@ def id_shorts_are_unique(referables: List["Referable"]) -> bool:
     Check that the :attr:`Referable.id_short`'s among the :paramref:`referables` are
     unique.
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     id_short_set = set()
     for referable in referables:
@@ -1129,7 +1129,7 @@ def id_shorts_are_unique(referables: List["Referable"]) -> bool:
 @implementation_specific
 def extension_names_are_unique(extensions: List["Extension"]) -> bool:
     """Check that the extension names are unique."""
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     name_set = set()
     for extension in extensions:
@@ -1146,7 +1146,7 @@ def submodel_elements_have_identical_semantic_ids(
     elements: List["Submodel_element"],
 ) -> bool:
     """Check that all semantic IDs are identical, if specified."""
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as a reference.
     semantic_id = None
     for element in elements:
@@ -1178,7 +1178,7 @@ def properties_or_ranges_have_value_type(
     elements: List["Submodel_element"], value_type: "Data_type_def_xsd"
 ) -> bool:
     """Check that all the :paramref:`elements` have the :paramref:`value_type`."""
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     for element in elements:
         if isinstance(element, (Property, Range)):
@@ -1192,7 +1192,7 @@ def properties_or_ranges_have_value_type(
 @implementation_specific
 def reference_key_values_equal(that: "Reference", other: "Reference") -> bool:
     """Check that the two references are equal by comparing their key values."""
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     if len(that.keys) != len(other.keys):
         return False
@@ -1431,7 +1431,7 @@ class Extension(Has_semantics):
 
     @implementation_specific
     def value_type_or_default(self) -> "Data_type_def_xsd":
-        # NOTE (mristin, 2022-04-7):
+        # NOTE (mristin):
         # This implementation will not be transpiled, but is given here as reference.
         return (
             self.value_type if self.value_type is not None else Data_type_def_xsd.String
@@ -1717,7 +1717,7 @@ class Has_kind(DBC):
 
     @implementation_specific
     def kind_or_default(self) -> "Modeling_kind":
-        # NOTE (mristin, 2022-04-7):
+        # NOTE (mristin):
         # This implementation will not be transpiled, but is given here as reference.
         return self.kind if self.kind is not None else Modeling_kind.Instance
 
@@ -1906,7 +1906,7 @@ class Qualifier(Has_semantics):
 
     @implementation_specific
     def kind_or_default(self) -> "Qualifier_kind":
-        # NOTE (mristin, 2022-05-24):
+        # NOTE (mristin):
         # This implementation will not be transpiled, but is given here as reference.
         return self.kind if self.kind is not None else Qualifier_kind.Concept_qualifier
 
@@ -2585,7 +2585,7 @@ class Submodel_element_list(Submodel_element):
 
     @implementation_specific
     def order_relevant_or_default(self) -> bool:
-        # NOTE (mristin, 2022-04-7):
+        # NOTE (mristin):
         # This implementation will not be transpiled, but is given here as reference.
         return self.order_relevant if self.order_relevant is not None else True
 
@@ -2798,7 +2798,7 @@ class Data_element(Submodel_element):
     @implementation_specific
     @ensure(lambda result: result in Valid_categories_for_data_element)
     def category_or_default(self) -> str:
-        # NOTE (mristin, 2022-04-7):
+        # NOTE (mristin):
         # This implementation will not be transpiled, but is given here as reference.
         return self.category if self.category is not None else "VARIABLE"
 
@@ -3858,7 +3858,7 @@ Valid_categories_for_concept_description: Set[str] = constant_set(
 Categories for :class:`Concept_description` as defined in :constraintref:`AASd-051`""",
 )
 
-# NOTE (mristin, 2022-08-19):
+# NOTE (mristin):
 # We make the following verification functions implementation-specific since the casts
 # are very clumsy to formalize and transpile in a readable way across languages.
 # For example, since Python does not have a null-coalescing operator, formalizing
@@ -3879,7 +3879,7 @@ def data_specification_IEC_61360s_for_property_or_value_have_appropriate_data_ty
     Check that the :attr:`Data_specification_IEC_61360.data_type` is defined
     appropriately for all data specifications whose content is given as IEC 61360.
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     return all(
         not (
@@ -3908,7 +3908,7 @@ def data_specification_IEC_61360s_for_reference_have_appropriate_data_type(
     Check that the :attr:`Data_specification_IEC_61360.data_type` is defined
     appropriately for all data specifications whose content is given as IEC 61360.
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     return all(
         not (
@@ -3937,7 +3937,7 @@ def data_specification_IEC_61360s_for_document_have_appropriate_data_type(
     Check that the :attr:`Data_specification_IEC_61360.data_type` is defined
     appropriately for all data specifications whose content is given as IEC 61360.
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     return all(
         not (
@@ -3966,7 +3966,7 @@ def data_specification_IEC_61360s_have_data_type(
     Check that the :attr:`Data_specification_IEC_61360.data_type` is defined for all
     data specifications whose content is given as IEC 61360.
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     return all(
         not (
@@ -3989,7 +3989,7 @@ def data_specification_IEC_61360s_have_value(
     Check that the :attr:`Data_specification_IEC_61360.value` is defined
     for all data specifications whose content is given as IEC 61360.
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
     return all(
         not (
@@ -4012,7 +4012,7 @@ def data_specification_IEC_61360s_have_definition_at_least_in_english(
     Check that the :attr:`Data_specification_IEC_61360.definition` is defined
     for all data specifications whose content is given as IEC 61360 at least in English.
     """
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin):
     # This implementation will not be transpiled, but is given here as reference.
 
     for data_specification in embedded_data_specifications:
@@ -4196,7 +4196,7 @@ class Concept_description(Identifiable, Has_data_specification):
     @implementation_specific
     @ensure(lambda result: result in Valid_categories_for_concept_description)
     def category_or_default(self) -> str:
-        # NOTE (mristin, 2022-04-7):
+        # NOTE (mristin):
         # This implementation will not be transpiled, but is given here as reference.
         return self.category if self.category is not None else "PROPERTY"
 
@@ -4281,7 +4281,7 @@ class Reference_types(Enum):
     "with type Submodel element list is an integer number denoting the position in "
     "the array of the submodel element list."
 )
-# NOTE (mristin, 2022-07-10):
+# NOTE (mristin):
 # We can write AASd-127 in this simpler form assuming that AASd-126 ensures that
 # only the last key can be a fragment reference.
 @invariant(
@@ -5074,7 +5074,8 @@ Data_type_IEC_61360_for_document: Set[Data_type_IEC_61360] = constant_set(
 )
 
 
-# NOTE (g1zzm0, 2022-07-21): There is no table for this class in the book at the moment.
+# NOTE (g1zzm0):
+# There is no table for this class in the book.
 class Level_type(Enum):
     Min = "Min"
     Max = "Max"

--- a/dev/tests/common.py
+++ b/dev/tests/common.py
@@ -175,7 +175,7 @@ def human_readable_property_name(name: str) -> str:
     >>> human_readable_property_name('URL_to_SaaS')
     'URL to SaaS'
     """
-    # NOTE (mristin, 2023-03-17):
+    # NOTE (mristin):
     # The code related to ``id`` and ``ids`` is necessary for v3rc2.
 
     if name == "id":

--- a/dev/tests/test_v3.py
+++ b/dev/tests/test_v3.py
@@ -137,7 +137,7 @@ class Test_matches_xs_any_URI(unittest.TestCase):
     # See: http://www.datypic.com/sc/xsd/t-xsd_anyURI.html
 
     def test_empty(self) -> None:
-        # NOTE (mristin, 2022-04-1):
+        # NOTE (mristin):
         # An empty string is a valid ``xs:anyURI``,
         # see https://lists.w3.org/Archives/Public/xml-dist-app/2003Mar/0076.html and
         # https://lists.w3.org/Archives/Public/xml-dist-app/2003Mar/0078.html
@@ -308,7 +308,7 @@ class Test_matches_xs_double(unittest.TestCase):
         assert not v3.matches_xs_double("12.34e-5.6")
 
     def test_edge_cases(self) -> None:
-        # NOTE (mristin, 2022-10-30):
+        # NOTE (mristin):
         # See: https://www.oreilly.com/library/view/xml-schema/0596002521/re67.html
         assert not v3.matches_xs_double("+INF")
         assert v3.matches_xs_double("-INF")
@@ -330,7 +330,7 @@ class Test_matches_xs_duration(unittest.TestCase):
     def test_integer(self) -> None:
         assert not v3.matches_xs_duration("1234")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-duration
 
     def test_valid_values(self) -> None:
@@ -392,7 +392,7 @@ class Test_matches_xs_float(unittest.TestCase):
         assert not v3.matches_xs_float("12.34e-5.6")
 
     def test_edge_cases(self) -> None:
-        # NOTE (mristin, 2022-10-30):
+        # NOTE (mristin):
         # See: https://www.oreilly.com/library/view/xml-schema/0596002521/re67.html
         assert not v3.matches_xs_float("+INF")
         assert v3.matches_xs_float("-INF")
@@ -411,7 +411,7 @@ class Test_matches_xs_g_day(unittest.TestCase):
     def test_free_form_text(self) -> None:
         assert not v3.matches_xs_g_day("some free form text")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-gday
 
     def test_valid_values(self) -> None:
@@ -438,7 +438,7 @@ class Test_matches_xs_g_month(unittest.TestCase):
     def test_free_form_text(self) -> None:
         assert not v3.matches_xs_g_month("some free form text")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-gmonth
 
     def test_valid_values(self) -> None:
@@ -465,7 +465,7 @@ class Test_matches_xs_g_month_day(unittest.TestCase):
     def test_free_form_text(self) -> None:
         assert not v3.matches_xs_g_month_day("some free form text")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-gmonthday
 
     def test_valid_values(self) -> None:
@@ -499,7 +499,7 @@ class Test_matches_xs_g_year(unittest.TestCase):
     def test_free_form_text(self) -> None:
         assert not v3.matches_xs_g_year("some free form text")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-gyear
 
     def test_valid_values(self) -> None:
@@ -520,7 +520,7 @@ class Test_matches_xs_g_year_month(unittest.TestCase):
     def test_free_form_text(self) -> None:
         assert not v3.matches_xs_g_year_month("some free form text")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-gyearmonth
 
     def test_valid_values(self) -> None:
@@ -551,7 +551,7 @@ class Test_matches_xs_hex_binary(unittest.TestCase):
     def test_free_form_text(self) -> None:
         assert not v3.matches_xs_hex_binary("some free form text")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-hexbinary
 
     def test_valid_values(self) -> None:
@@ -575,7 +575,7 @@ class Test_matches_xs_time(unittest.TestCase):
     def test_free_form_text(self) -> None:
         assert not v3.matches_xs_time("some free form text")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-time
 
     def test_valid_values(self) -> None:
@@ -867,7 +867,7 @@ _META_MODEL: tests.common.MetaModel = tests.common.load_meta_model(
 
 
 class Test_assertions(unittest.TestCase):
-    # NOTE (mristin, 2023-01-25):
+    # NOTE (mristin):
     # We do not state "ID" as an abbreviation (which might imply "Identity Document"),
     # but rather expect "Id" or "id", short for "identifier".
     #
@@ -1108,7 +1108,7 @@ class Test_assertions(unittest.TestCase):
                     )
 
             elif isinstance(our_type, intermediate.ConstrainedPrimitive):
-                # NOTE (mristin, 2022-08-19):
+                # NOTE (mristin):
                 # There are no names to be checked beneath the constrained primitive.
                 pass
 
@@ -1494,31 +1494,31 @@ Observed literals: {sorted(literal_set)!r}""")
             ):
                 continue
 
-            # NOTE (mristin, 2023-03-17):
+            # NOTE (mristin):
             # We can not assert that ID-short is non-None in ``Submodel_element`` as
             # the submodel elements can be in the value of ``Submodel_element_list``.
             if our_type.is_subclass_of(submodel_element_cls):
                 continue
 
-            # NOTE (mristin, 2023-03-17):
+            # NOTE (mristin):
             # We can not assert that ID-short is non-None in this class as
             # ``Submodel_element`` inherits from it, and the submodel elements can be
             # in the value of ``Submodel_element_list``.
             if id(submodel_element_cls) in our_type.descendant_id_set:
                 continue
 
-            # NOTE (mristin, 2023-03-22):
+            # NOTE (mristin):
             # Identifiables are not affected by Constraint-117 so their ID-shorts remain
             # optional.
             if our_type.is_subclass_of(identifiable_cls):
                 continue
 
-            # NOTE (mristin, 2023-03-17):
+            # NOTE (mristin):
             # Constraint AASd-117 considers only the class ``Referable``.
             if not our_type.is_subclass_of(referable_cls):
                 continue
 
-            # NOTE (mristin, 2023-03-21):
+            # NOTE (mristin):
             # We use type strengthening to implement 117.
             if Identifier("ID_short") not in our_type.properties_by_name:
                 errors.append(
@@ -1573,7 +1573,7 @@ Observed literals: {sorted(literal_set)!r}""")
                 ):
                     continue
 
-                # NOTE (mristin, 2023-03-17):
+                # NOTE (mristin):
                 # All Referable classes already have to define the constraint as
                 # their invariant (see the previous test), so we do not have to check
                 # their ID-shorts here.
@@ -1677,7 +1677,7 @@ Observed literals: {sorted(literal_set)!r}""")
                     f"but got: {type_anno.items}"
                 )
 
-                # NOTE (mristin, 2023-03-17):
+                # NOTE (mristin):
                 # All Referable classes already have to define the constraint as
                 # their invariant (see the test above), so we do not have to check
                 # their ID-shorts here.

--- a/dev/tests/test_v3_1.py
+++ b/dev/tests/test_v3_1.py
@@ -143,7 +143,7 @@ class Test_matches_xs_any_URI(unittest.TestCase):
     # See: http://www.datypic.com/sc/xsd/t-xsd_anyURI.html
 
     def test_empty(self) -> None:
-        # NOTE (mristin, 2022-04-1):
+        # NOTE (mristin):
         # An empty string is a valid ``xs:anyURI``,
         # see https://lists.w3.org/Archives/Public/xml-dist-app/2003Mar/0076.html and
         # https://lists.w3.org/Archives/Public/xml-dist-app/2003Mar/0078.html
@@ -308,7 +308,7 @@ class Test_matches_xs_double(unittest.TestCase):
         assert not v3_1.matches_xs_double("12.34e-5.6")
 
     def test_edge_cases(self) -> None:
-        # NOTE (mristin, 2022-10-30):
+        # NOTE (mristin):
         # See: https://www.oreilly.com/library/view/xml-schema/0596002521/re67.html
         assert not v3_1.matches_xs_double("+INF")
         assert v3_1.matches_xs_double("-INF")
@@ -330,7 +330,7 @@ class Test_matches_xs_duration(unittest.TestCase):
     def test_integer(self) -> None:
         assert not v3_1.matches_xs_duration("1234")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-duration
 
     def test_valid_values(self) -> None:
@@ -392,7 +392,7 @@ class Test_matches_xs_float(unittest.TestCase):
         assert not v3_1.matches_xs_float("12.34e-5.6")
 
     def test_edge_cases(self) -> None:
-        # NOTE (mristin, 2022-10-30):
+        # NOTE (mristin):
         # See: https://www.oreilly.com/library/view/xml-schema/0596002521/re67.html
         assert not v3_1.matches_xs_float("+INF")
         assert v3_1.matches_xs_float("-INF")
@@ -411,7 +411,7 @@ class Test_matches_xs_g_day(unittest.TestCase):
     def test_free_form_text(self) -> None:
         assert not v3_1.matches_xs_g_day("some free form text")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-gday
 
     def test_valid_values(self) -> None:
@@ -438,7 +438,7 @@ class Test_matches_xs_g_month(unittest.TestCase):
     def test_free_form_text(self) -> None:
         assert not v3_1.matches_xs_g_month("some free form text")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-gmonth
 
     def test_valid_values(self) -> None:
@@ -465,7 +465,7 @@ class Test_matches_xs_g_month_day(unittest.TestCase):
     def test_free_form_text(self) -> None:
         assert not v3_1.matches_xs_g_month_day("some free form text")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-gmonthday
 
     def test_valid_values(self) -> None:
@@ -499,7 +499,7 @@ class Test_matches_xs_g_year(unittest.TestCase):
     def test_free_form_text(self) -> None:
         assert not v3_1.matches_xs_g_year("some free form text")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-gyear
 
     def test_valid_values(self) -> None:
@@ -520,7 +520,7 @@ class Test_matches_xs_g_year_month(unittest.TestCase):
     def test_free_form_text(self) -> None:
         assert not v3_1.matches_xs_g_year_month("some free form text")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-gyearmonth
 
     def test_valid_values(self) -> None:
@@ -551,7 +551,7 @@ class Test_matches_xs_hex_binary(unittest.TestCase):
     def test_free_form_text(self) -> None:
         assert not v3_1.matches_xs_hex_binary("some free form text")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-hexbinary
 
     def test_valid_values(self) -> None:
@@ -575,7 +575,7 @@ class Test_matches_xs_time(unittest.TestCase):
     def test_free_form_text(self) -> None:
         assert not v3_1.matches_xs_time("some free form text")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-time
 
     def test_valid_values(self) -> None:
@@ -867,7 +867,7 @@ _META_MODEL: tests.common.MetaModel = tests.common.load_meta_model(
 
 
 class Test_assertions(unittest.TestCase):
-    # NOTE (mristin, 2023-01-25):
+    # NOTE (mristin):
     # We do not state "ID" as an abbreviation (which might imply "Identity Document"),
     # but rather expect "Id" or "id", short for "identifier".
     #
@@ -1108,7 +1108,7 @@ class Test_assertions(unittest.TestCase):
                     )
 
             elif isinstance(our_type, intermediate.ConstrainedPrimitive):
-                # NOTE (mristin, 2022-08-19):
+                # NOTE (mristin):
                 # There are no names to be checked beneath the constrained primitive.
                 pass
 
@@ -1494,31 +1494,31 @@ Observed literals: {sorted(literal_set)!r}""")
             ):
                 continue
 
-            # NOTE (mristin, 2023-03-17):
+            # NOTE (mristin):
             # We can not assert that ID-short is non-None in ``Submodel_element`` as
             # the submodel elements can be in the value of ``Submodel_element_list``.
             if our_type.is_subclass_of(submodel_element_cls):
                 continue
 
-            # NOTE (mristin, 2023-03-17):
+            # NOTE (mristin):
             # We can not assert that ID-short is non-None in this class as
             # ``Submodel_element`` inherits from it, and the submodel elements can be
             # in the value of ``Submodel_element_list``.
             if id(submodel_element_cls) in our_type.descendant_id_set:
                 continue
 
-            # NOTE (mristin, 2023-03-22):
+            # NOTE (mristin):
             # Identifiables are not affected by Constraint-117 so their ID-shorts remain
             # optional.
             if our_type.is_subclass_of(identifiable_cls):
                 continue
 
-            # NOTE (mristin, 2023-03-17):
+            # NOTE (mristin):
             # Constraint AASd-117 considers only the class ``Referable``.
             if not our_type.is_subclass_of(referable_cls):
                 continue
 
-            # NOTE (mristin, 2023-03-21):
+            # NOTE (mristin):
             # We use type strengthening to implement 117.
             if Identifier("ID_short") not in our_type.properties_by_name:
                 errors.append(
@@ -1573,7 +1573,7 @@ Observed literals: {sorted(literal_set)!r}""")
                 ):
                     continue
 
-                # NOTE (mristin, 2023-03-17):
+                # NOTE (mristin):
                 # All Referable classes already have to define the constraint as
                 # their invariant (see the previous test), so we do not have to check
                 # their ID-shorts here.
@@ -1677,7 +1677,7 @@ Observed literals: {sorted(literal_set)!r}""")
                     f"but got: {type_anno.items}"
                 )
 
-                # NOTE (mristin, 2023-03-17):
+                # NOTE (mristin):
                 # All Referable classes already have to define the constraint as
                 # their invariant (see the test above), so we do not have to check
                 # their ID-shorts here.

--- a/dev/tests/test_v3rc2.py
+++ b/dev/tests/test_v3rc2.py
@@ -107,7 +107,7 @@ class Test_matches_xs_any_URI(unittest.TestCase):
     # See: http://www.datypic.com/sc/xsd/t-xsd_anyURI.html
 
     def test_empty(self) -> None:
-        # NOTE (mristin, 2022-04-1):
+        # NOTE (mristin):
         # An empty string is a valid ``xs:anyURI``,
         # see https://lists.w3.org/Archives/Public/xml-dist-app/2003Mar/0076.html and
         # https://lists.w3.org/Archives/Public/xml-dist-app/2003Mar/0078.html
@@ -311,7 +311,7 @@ class Test_matches_xs_double(unittest.TestCase):
         assert not v3rc2.matches_xs_double("12.34e-5.6")
 
     def test_edge_cases(self) -> None:
-        # NOTE (mristin, 2022-10-30):
+        # NOTE (mristin):
         # See: https://www.oreilly.com/library/view/xml-schema/0596002521/re67.html
         assert not v3rc2.matches_xs_double("+INF")
         assert v3rc2.matches_xs_double("-INF")
@@ -333,7 +333,7 @@ class Test_matches_xs_duration(unittest.TestCase):
     def test_integer(self) -> None:
         assert not v3rc2.matches_xs_duration("1234")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-duration
 
     def test_valid_values(self) -> None:
@@ -395,7 +395,7 @@ class Test_matches_xs_float(unittest.TestCase):
         assert not v3rc2.matches_xs_float("12.34e-5.6")
 
     def test_edge_cases(self) -> None:
-        # NOTE (mristin, 2022-10-30):
+        # NOTE (mristin):
         # See: https://www.oreilly.com/library/view/xml-schema/0596002521/re67.html
         assert not v3rc2.matches_xs_float("+INF")
         assert v3rc2.matches_xs_float("-INF")
@@ -414,7 +414,7 @@ class Test_matches_xs_g_day(unittest.TestCase):
     def test_free_form_text(self) -> None:
         assert not v3rc2.matches_xs_g_day("some free form text")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-gday
 
     def test_valid_values(self) -> None:
@@ -441,7 +441,7 @@ class Test_matches_xs_g_month(unittest.TestCase):
     def test_free_form_text(self) -> None:
         assert not v3rc2.matches_xs_g_month("some free form text")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-gmonth
 
     def test_valid_values(self) -> None:
@@ -468,7 +468,7 @@ class Test_matches_xs_g_month_day(unittest.TestCase):
     def test_free_form_text(self) -> None:
         assert not v3rc2.matches_xs_g_month_day("some free form text")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-gmonthday
 
     def test_valid_values(self) -> None:
@@ -502,7 +502,7 @@ class Test_matches_xs_g_year(unittest.TestCase):
     def test_free_form_text(self) -> None:
         assert not v3rc2.matches_xs_g_year("some free form text")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-gyear
 
     def test_valid_values(self) -> None:
@@ -523,7 +523,7 @@ class Test_matches_xs_g_year_month(unittest.TestCase):
     def test_free_form_text(self) -> None:
         assert not v3rc2.matches_xs_g_year_month("some free form text")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-gyearmonth
 
     def test_valid_values(self) -> None:
@@ -554,7 +554,7 @@ class Test_matches_xs_hex_binary(unittest.TestCase):
     def test_free_form_text(self) -> None:
         assert not v3rc2.matches_xs_hex_binary("some free form text")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-hexbinary
 
     def test_valid_values(self) -> None:
@@ -578,7 +578,7 @@ class Test_matches_xs_time(unittest.TestCase):
     def test_free_form_text(self) -> None:
         assert not v3rc2.matches_xs_time("some free form text")
 
-    # NOTE (mristin, 2022-04-6):
+    # NOTE (mristin):
     # See https://www.data2type.de/xml-xslt-xslfo/xml-schema/datentypen-referenz/xs-time
 
     def test_valid_values(self) -> None:
@@ -920,7 +920,7 @@ _META_MODEL: tests.common.MetaModel = tests.common.load_meta_model(
 
 
 class Test_assertions(unittest.TestCase):
-    # NOTE (mristin, 2022-05-26):
+    # NOTE (mristin):
     # We do not state "ID" as an abbreviation (which might imply "Identity Document"),
     # but rather expect "Id" or "id", short for "identifier".
     #
@@ -1128,7 +1128,7 @@ class Test_assertions(unittest.TestCase):
         for our_type in symbol_table.our_types:
             errors.extend(Test_assertions.check_class_name(name=our_type.name))
 
-            # NOTE (mristin, 2022-08-19):
+            # NOTE (mristin):
             # We descend and check literals, properties *etc.*
 
             if isinstance(our_type, intermediate.Enumeration):
@@ -1138,7 +1138,7 @@ class Test_assertions(unittest.TestCase):
                     )
 
             elif isinstance(our_type, intermediate.ConstrainedPrimitive):
-                # NOTE (mristin, 2022-08-19):
+                # NOTE (mristin):
                 # There are no names to be checked beneath the constrained primitive.
                 pass
 

--- a/htmlgen/htmlgen/transpilation.py
+++ b/htmlgen/htmlgen/transpilation.py
@@ -66,7 +66,7 @@ class _Transpiler(
             parent=environment
         )
 
-        # NOTE (mristin, 2023-10-20):
+        # NOTE (mristin):
         # Keep track whenever we define a variable name, so that we can know how to
         # resolve it as a name in the Python code.
         #
@@ -317,7 +317,7 @@ class _Transpiler(
         if isinstance(node.antecedent, no_parentheses_types_in_this_context):
             not_antecedent = f"{not_html} {antecedent}"
         else:
-            # NOTE (mristin, 2023-10-20):
+            # NOTE (mristin):
             # This is a very rudimentary heuristic for breaking the lines, and can be
             # greatly improved by rendering into Python code. However, at this point, we
             # lack time for more sophisticated reformatting approaches.
@@ -330,7 +330,7 @@ class _Transpiler(
                 not_antecedent = f"{not_html} {LPAREN}{antecedent}{RPAREN}"
 
         if not isinstance(node.consequent, no_parentheses_types_in_this_context):
-            # NOTE (mristin, 2023-10-20):
+            # NOTE (mristin):
             # This is a very rudimentary heuristic for breaking the lines, and can be
             # greatly improved by rendering into Python code. However, at this point, we
             # lack time for more sophisticated reformatting approaches.
@@ -413,7 +413,7 @@ class _Transpiler(
                 node.original_node, "Failed to transpile the function call", errors
             )
 
-        # NOTE (mristin, 2023-10-20):
+        # NOTE (mristin):
         # The validity of the arguments is checked in
         # :py:func:`aas_core_codegen.intermediate._translate.translate`, so we do not
         # have to test for argument arity here.
@@ -618,7 +618,7 @@ class _Transpiler(
             )
 
             if not isinstance(value_node, no_parentheses_types_in_this_context):
-                # NOTE (mristin, 2023-10-20):
+                # NOTE (mristin):
                 # This is a very rudimentary heuristic for breaking the lines, and can
                 # be greatly improved by rendering into Python code. However, at this
                 # point, we lack time for more sophisticated reformatting approaches.
@@ -756,7 +756,7 @@ class _Transpiler(
 
         parts = []  # type: List[str]
 
-        # NOTE (mristin, 2023-10-20):
+        # NOTE (mristin):
         # See which quotes occur more often in the non-interpolated parts, so that we
         # pick the escaping scheme which will result in as little escapes as possible.
         double_quotes_count = 0
@@ -964,7 +964,7 @@ class _Transpiler(
         if isinstance(node.target, parse_tree.Name):
             type_anno = self._environment.find(identifier=node.target.identifier)
             if type_anno is None:
-                # NOTE (mristin, 2023-10-20):
+                # NOTE (mristin):
                 # This is a variable definition as we did not specify the identifier
                 # in the environment.
 
@@ -988,7 +988,7 @@ class _Transpiler(
 
         assign_html = "<span class='o'>=</span>"
 
-        # NOTE (mristin, 2023-10-20):
+        # NOTE (mristin):
         # This is a rudimentary heuristic for basic line breaks, but works well in
         # practice.
         if "\n" not in value and len(value) > 50:
@@ -1016,7 +1016,7 @@ class _Transpiler(
 
         assert value is not None
 
-        # NOTE (mristin, 2023-10-20):
+        # NOTE (mristin):
         # This is a rudimentary heuristic for basic line breaks, but works well in
         # practice.
         if "\n" not in value and len(value) > 50:
@@ -1121,7 +1121,7 @@ def transpile_body_of_verification(
     ):
         parsed_body = verification.parsed.body
     elif isinstance(verification, intermediate.ImplementationSpecificVerification):
-        # NOTE (mristin, 2023-10-20):
+        # NOTE (mristin):
         # We can not parse the implementation specific verification, so we simply
         # return a comment.
         return (


### PR DESCRIPTION
We remove the dates from the note comments (such as ``# NOTE (mristin, 2022-11-24``) since a lot of code is copy-pasted including these comments. The reader is then confused when s/he reads the code which was written for the first time long after the comment, so we remove the dates to avoid this confusion.